### PR TITLE
Make a decorator to handle transactions

### DIFF
--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -108,7 +108,6 @@ def update(db: Session, family: FamilyDTO) -> Optional[FamilyDTO]:
         .where(Family.import_id == family.import_id)
         .values(title=new_values["title"], description=new_values["summary"])
     )
-    db.commit()
 
     if result.rowcount == 0:  # type: ignore
         return

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -125,12 +125,11 @@ def create(db: Session, family: FamilyDTO) -> Optional[FamilyDTO]:
     try:
         new_family = _family_from_dto(family)
         db.add(new_family)
-        db.commit()
     except Exception as e:
         _LOGGER.error(e)
         return
 
-    return get(db, str(new_family.import_id))
+    return family
 
 
 def delete(db: Session, import_id: str) -> bool:
@@ -141,6 +140,5 @@ def delete(db: Session, import_id: str) -> bool:
     :return bool: True if deleted False if not.
     """
     result = db.execute(db_delete(Family).where(Family.import_id == import_id))
-    db.commit()
 
     return result.rowcount > 0  # type: ignore

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -66,12 +66,15 @@ def update(family: FamilyDTO) -> Optional[FamilyDTO]:
     :return Optional[FamilyDTO]: The updated Family or None if not updated.
     """
     id.validate(family.import_id)
+    db = db_session.get_db()
     try:
-        with db_session.get_db() as db:
-            return family_repo.update(db, family)
+        return family_repo.update(db, family)
     except exc.SQLAlchemyError as e:
         _LOGGER.error(e)
+        db.rollback()
         raise RepositoryError(str(e))
+    finally:
+        db.commit()
 
 
 def create(family: FamilyDTO) -> Optional[FamilyDTO]:

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -68,11 +68,11 @@ def update(family: FamilyDTO, db: Session = db_session.get_db()) -> Optional[Fam
     :return Optional[FamilyDTO]: The updated Family or None if not updated.
     """
     id.validate(family.import_id)
-    new_family = family_repo.update(db, family)
-    return new_family
+    return family_repo.update(db, family)
 
 
-def create(family: FamilyDTO) -> Optional[FamilyDTO]:
+@db_session.with_transaction
+def create(family: FamilyDTO, db: Session = db_session.get_db()) -> Optional[FamilyDTO]:
     """
     Creates a new Family with the values passed.
 
@@ -82,20 +82,11 @@ def create(family: FamilyDTO) -> Optional[FamilyDTO]:
     :return Optional[FamilyDTO]: The new created Family or None if unsuccessful.
     """
     id.validate(family.import_id)
-    with db_session.get_db() as db:
-        try:
-            new_family = family_repo.create(db, family)
-            db.commit()
-            return new_family
-        except exc.SQLAlchemyError as e:
-            _LOGGER.error(e)
-            db.rollback()
-            raise RepositoryError(str(e))
-        finally:
-            db.close()
+    return family_repo.create(db, family)
 
 
-def delete(import_id: str) -> bool:
+@db_session.with_transaction
+def delete(import_id: str, db: Session = db_session.get_db()) -> bool:
     """
     Deletes the Family specified by the import_id.
 
@@ -105,9 +96,4 @@ def delete(import_id: str) -> bool:
     :return bool: True if deleted else False.
     """
     id.validate(import_id)
-    try:
-        with db_session.get_db() as db:
-            return family_repo.delete(db, import_id)
-    except exc.SQLAlchemyError as e:
-        _LOGGER.error(e)
-        raise RepositoryError(str(e))
+    return family_repo.delete(db, import_id)

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -7,8 +7,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 import app.db.session as db_session
 from app.main import app
-from integration_tests.mocks.bad_family_repo import mock_family_repo
+from integration_tests.mocks.bad_family_repo import mock_bad_family_repo
 import app.repository.family as family_repo
+from integration_tests.mocks.rollback_family_repo import mock_rollback_family_repo
 
 
 def get_test_db_url() -> str:
@@ -60,5 +61,12 @@ def client(test_db, monkeypatch):
 @pytest.fixture
 def bad_family_repo(monkeypatch, mocker):
     """Mocks the repository for a single test."""
-    mock_family_repo(family_repo, monkeypatch, mocker)
+    mock_bad_family_repo(family_repo, monkeypatch, mocker)
+    yield family_repo
+
+
+@pytest.fixture
+def rollback_family_repo(monkeypatch, mocker):
+    """Mocks the repository for a single test."""
+    mock_rollback_family_repo(family_repo, monkeypatch, mocker)
     yield family_repo

--- a/integration_tests/mocks/bad_family_repo.py
+++ b/integration_tests/mocks/bad_family_repo.py
@@ -29,7 +29,7 @@ def mock_delete_family(_, import_id: str) -> bool:
     raise RepositoryError("Bad Repo")
 
 
-def mock_family_repo(family_repo, monkeypatch: MonkeyPatch, mocker):
+def mock_bad_family_repo(family_repo, monkeypatch: MonkeyPatch, mocker):
     monkeypatch.setattr(family_repo, "get", mock_get_family)
     mocker.spy(family_repo, "get")
 

--- a/integration_tests/mocks/rollback_family_repo.py
+++ b/integration_tests/mocks/rollback_family_repo.py
@@ -7,24 +7,26 @@ from app.model.family import FamilyDTO
 
 def mock_rollback_family_repo(family_repo, monkeypatch: MonkeyPatch, mocker):
     actual_update = family_repo.update
+    actual_create = family_repo.create
+    actual_delete = family_repo.delete
 
     def mock_update_family(db, data: FamilyDTO) -> Optional[FamilyDTO]:
         actual_update(db, data)
         raise NoResultFound()
 
-    # def mock_create_family(db, data: FamilyDTO) -> Optional[FamilyDTO]:
-    #     actual_family_repo.create(db, data)
-    #     raise NoResultFound()
+    def mock_create_family(db, data: FamilyDTO) -> Optional[FamilyDTO]:
+        actual_create(db, data)
+        raise NoResultFound()
 
-    # def mock_delete_family(db, import_id: str) -> bool:
-    #     actual_family_repo.create(db, import_id)
-    #     raise NoResultFound()
+    def mock_delete_family(db, import_id: str) -> bool:
+        actual_delete(db, import_id)
+        raise NoResultFound()
 
     monkeypatch.setattr(family_repo, "update", mock_update_family)
     mocker.spy(family_repo, "update")
 
-    # monkeypatch.setattr(family_repo, "create", mock_create_family)
-    # mocker.spy(family_repo, "create")
+    monkeypatch.setattr(family_repo, "create", mock_create_family)
+    mocker.spy(family_repo, "create")
 
-    # monkeypatch.setattr(family_repo, "delete", mock_delete_family)
-    # mocker.spy(family_repo, "delete")
+    monkeypatch.setattr(family_repo, "delete", mock_delete_family)
+    mocker.spy(family_repo, "delete")

--- a/integration_tests/mocks/rollback_family_repo.py
+++ b/integration_tests/mocks/rollback_family_repo.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from pytest import MonkeyPatch
+from sqlalchemy.exc import NoResultFound
+
+from app.model.family import FamilyDTO
+
+
+def mock_rollback_family_repo(family_repo, monkeypatch: MonkeyPatch, mocker):
+    actual_update = family_repo.update
+
+    def mock_update_family(db, data: FamilyDTO) -> Optional[FamilyDTO]:
+        actual_update(db, data)
+        raise NoResultFound()
+
+    # def mock_create_family(db, data: FamilyDTO) -> Optional[FamilyDTO]:
+    #     actual_family_repo.create(db, data)
+    #     raise NoResultFound()
+
+    # def mock_delete_family(db, import_id: str) -> bool:
+    #     actual_family_repo.create(db, import_id)
+    #     raise NoResultFound()
+
+    monkeypatch.setattr(family_repo, "update", mock_update_family)
+    mocker.spy(family_repo, "update")
+
+    # monkeypatch.setattr(family_repo, "create", mock_create_family)
+    # mocker.spy(family_repo, "create")
+
+    # monkeypatch.setattr(family_repo, "delete", mock_delete_family)
+    # mocker.spy(family_repo, "delete")

--- a/integration_tests/test_family.py
+++ b/integration_tests/test_family.py
@@ -154,6 +154,25 @@ def test_update_family_200(client: TestClient, test_db: Session):
     assert db_family.description == "just a test"
 
 
+def test_update_family_rollback(
+    client: TestClient, test_db: Session, rollback_family_repo
+):
+    _setup_db(test_db)
+    new_family = create_family_dto(
+        import_id="A.0.0.2",
+        title="Updated Title",
+        summary="just a test",
+    )
+    response = client.put("/api/v1/families", json=new_family.dict())
+    assert response.status_code == 503
+
+    db_family: Family = (
+        test_db.query(Family).filter(Family.import_id == "A.0.0.2").one()
+    )
+    assert db_family.title != "Updated Title"
+    assert db_family.description != "just a test"
+
+
 def test_update_family_404(client: TestClient, test_db: Session):
     _setup_db(test_db)
     new_family = create_family_dto(


### PR DESCRIPTION
# Description

- Create a `with_tranaction` decorator to handle tranactions, i.e. begin/rollback/commit
- Change the service function signature to take a keyword arg `db` this defaults to a normal db session
- The decorator will inject the managed transaction if used

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
