### PR TITLE
PDCT-310 Get, search, and count family events

### DIFF
--- a/app/api/api_v1/routers/__init__.py
+++ b/app/api/api_v1/routers/__init__.py
@@ -4,3 +4,4 @@ from .auth import auth_router
 from .document import document_router
 from .config import config_router
 from .analytics import analytics_router
+from .event import event_router

--- a/app/api/api_v1/routers/analytics.py
+++ b/app/api/api_v1/routers/analytics.py
@@ -32,7 +32,7 @@ async def get_analytics_summary() -> SummaryDTO:
     if any(summary_value is None for _, summary_value in summary_dto):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Analytics summary not found",
+            detail="Analytics summary not found",
         )
 
     return summary_dto

--- a/app/api/api_v1/routers/event.py
+++ b/app/api/api_v1/routers/event.py
@@ -1,0 +1,86 @@
+"""Endpoints for managing Family Event entities."""
+import logging
+
+from fastapi import APIRouter, HTTPException, status
+
+import app.service.event as event_service
+from app.errors import RepositoryError, ValidationError
+from app.model.event import EventReadDTO
+
+event_router = r = APIRouter()
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@r.get(
+    "/events",
+    response_model=list[EventReadDTO],
+)
+async def get_all_events() -> list[EventReadDTO]:
+    """
+    Returns all family events.
+
+    :return EventDTO: returns a EventDTO if the event is found.
+    """
+    found_events = event_service.all()
+
+    if not found_events:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No family events found",
+        )
+
+    return found_events
+
+
+@r.get(
+    "/events/",
+    response_model=list[EventReadDTO],
+)
+async def search_event(q: str = "") -> list[EventReadDTO]:
+    """
+    Searches for family events matching the "q" URL parameter.
+
+    :param str q: The string to match, defaults to ""
+    :raises HTTPException: If nothing found a 404 is returned.
+    :return list[EventDTO]: A list of matching events.
+    """
+    events_found = event_service.search(q)
+
+    if not events_found:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Events not found for term: {q}",
+        )
+
+    return events_found
+
+
+@r.get(
+    "/events/{import_id}",
+    response_model=EventReadDTO,
+)
+async def get_event(import_id: str) -> EventReadDTO:
+    """
+    Returns a specific family event given an import id.
+
+    :param str import_id: Specified import_id.
+    :raises HTTPException: If the event is not found a 404 is returned.
+    :return EventDTO: returns a EventDTO if the event is found.
+    """
+    try:
+        event = event_service.get(import_id)
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
+    except RepositoryError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message
+        )
+
+    if event is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Event not found: {import_id}",
+        )
+
+    return event

--- a/app/api/api_v1/routers/event.py
+++ b/app/api/api_v1/routers/event.py
@@ -45,7 +45,12 @@ async def search_event(q: str = "") -> list[EventReadDTO]:
     :raises HTTPException: If nothing found a 404 is returned.
     :return list[EventDTO]: A list of matching events.
     """
-    events_found = event_service.search(q)
+    try:
+        events_found = event_service.search(q)
+    except RepositoryError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message
+        )
 
     if not events_found:
         raise HTTPException(

--- a/app/clients/db/models/app/authorisation.py
+++ b/app/clients/db/models/app/authorisation.py
@@ -34,6 +34,7 @@ class AuthEndpoint(str, enum.Enum):
     DOCUMENT = "DOCUMENTS"
     CONFIG = "CONFIG"
     ANALYTICS = "ANALYTICS"
+    EVENT = "EVENTS"
 
 
 class AuthAccess(str, enum.Enum):
@@ -74,6 +75,10 @@ AUTH_TABLE: AuthMap = {
     },
     # Analytics
     AuthEndpoint.ANALYTICS: {
+        AuthOperation.READ: AuthAccess.USER,
+    },
+    # Event
+    AuthEndpoint.EVENT: {
         AuthOperation.CREATE: AuthAccess.USER,
         AuthOperation.READ: AuthAccess.USER,
         AuthOperation.UPDATE: AuthAccess.USER,

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.api.api_v1.routers import (
     document_router,
     config_router,
     analytics_router,
+    event_router,
 )
 from fastapi import FastAPI, Depends
 from fastapi_health import health
@@ -69,6 +70,13 @@ app.include_router(
     analytics_router,
     prefix="/api/v1",
     tags=["analytics"],
+    dependencies=[Depends(check_user_auth)],
+)
+
+app.include_router(
+    event_router,
+    prefix="/api/v1",
+    tags=["events"],
     dependencies=[Depends(check_user_auth)],
 )
 

--- a/app/model/event.py
+++ b/app/model/event.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Optional
+
+from app.clients.db.models.law_policy.family import (
+    EventStatus,
+)
+
+
+class EventReadDTO(BaseModel):
+    """JSON Representation of a Event for reading."""
+
+    # From FamilyEvent
+    import_id: str
+    event_title: str
+    date: datetime
+    event_type_value: str
+    family_import_id: str
+    family_document_import_id: Optional[str] = None
+    event_status: EventStatus

--- a/app/repository/__init__.py
+++ b/app/repository/__init__.py
@@ -7,3 +7,4 @@ import app.repository.document as document_repo
 import app.repository.app_user as app_user_repo
 import app.clients.aws.s3bucket as s3bucket_repo
 import app.repository.config as config_repo
+import app.repository.event as event_repo

--- a/app/repository/event.py
+++ b/app/repository/event.py
@@ -1,0 +1,129 @@
+"""Operations on the repository for the Family entity."""
+
+import logging
+from datetime import datetime
+from typing import Optional, Tuple, cast
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Query, Session
+from sqlalchemy.exc import NoResultFound
+from sqlalchemy_utils import escape_like
+
+from app.clients.db.models.law_policy import (
+    EventStatus,
+    FamilyEvent,
+    Family,
+    FamilyDocument,
+)
+from app.model.event import EventReadDTO
+
+
+_LOGGER = logging.getLogger(__name__)
+
+FamilyEventTuple = Tuple[FamilyEvent, Family, FamilyDocument]
+
+
+def _get_query(db: Session) -> Query:
+    # NOTE: SqlAlchemy will make a complete hash of the query generation
+    #       if columns are used in the query() call. Therefore, entire
+    #       objects are returned.
+    return (
+        db.query(FamilyEvent, Family, FamilyDocument)
+        .filter(FamilyEvent.family_import_id == Family.import_id)
+        .join(
+            FamilyDocument,
+            FamilyDocument.family_import_id == FamilyEvent.family_document_import_id,
+            isouter=True,
+        )
+    )
+
+
+def _event_to_dto(db: Session, family_event_meta: FamilyEventTuple) -> EventReadDTO:
+    family_event = family_event_meta[0]
+
+    family_document_import_id = (
+        None
+        if family_event.family_document_import_id is None
+        else cast(str, family_event.family_document_import_id)
+    )
+
+    return EventReadDTO(
+        import_id=cast(str, family_event.import_id),
+        event_title=cast(str, family_event.title),
+        date=cast(datetime, family_event.date),
+        family_import_id=cast(str, family_event.family_import_id),
+        family_document_import_id=family_document_import_id,
+        event_type_value=cast(str, family_event.event_type_name),
+        event_status=cast(EventStatus, family_event.status),
+    )
+
+
+def all(db: Session) -> list[EventReadDTO]:
+    """
+    Returns all family events.
+
+    :param db Session: The database connection.
+    :return Optional[EventReadDTO]: All family events in the database.
+    """
+    family_event_metas = _get_query(db).all()
+
+    if not family_event_metas:
+        return []
+
+    result = [_event_to_dto(db, event_meta) for event_meta in family_event_metas]
+    return result
+
+
+def get(db: Session, import_id: str) -> Optional[EventReadDTO]:
+    """
+    Gets a single family event from the repository.
+
+    :param db Session: The database connection.
+    :param str import_id: The import_id of the event.
+    :return Optional[EventReadDTO]: A single family event or nothing.
+    """
+    try:
+        family_event_meta = (
+            _get_query(db).filter(FamilyEvent.import_id == import_id).one()
+        )
+    except NoResultFound as e:
+        _LOGGER.error(e)
+        return
+
+    return _event_to_dto(db, family_event_meta)
+
+
+def search(db: Session, search_term: str) -> list[EventReadDTO]:
+    """
+    Get family events matching a search term on the event title or type.
+
+    :param db Session: The database connection.
+    :param str search_term: Any search term to filter on the event title
+        or event type name.
+    :return list[EventReadDTO]: A list of matching family events.
+    """
+    term = f"%{escape_like(search_term)}%"
+    search = or_(FamilyEvent.title.ilike(term), FamilyEvent.event_type_name.ilike(term))
+    found = _get_query(db).filter(search).all()
+
+    if not found:
+        return []
+
+    return [_event_to_dto(db, f) for f in found]
+
+
+def count(db: Session) -> Optional[int]:
+    """
+    Counts the number of family events in the repository.
+
+    :param db Session: The database connection.
+    :return Optional[int]: The number of family events in the repository
+        or nothing.
+    """
+    try:
+        n_events = _get_query(db).count()
+    except NoResultFound as e:
+        _LOGGER.error(e)
+        return
+
+    return n_events

--- a/app/service/analytics.py
+++ b/app/service/analytics.py
@@ -7,13 +7,14 @@ the count of available entities.
 import logging
 
 from pydantic import ConfigDict, validate_call
+from sqlalchemy import exc
+
 from app.errors import RepositoryError
 from app.model.analytics import SummaryDTO
 import app.service.collection as collection_service
 import app.service.document as document_service
 import app.service.family as family_service
-import app.clients.db.session as db_session
-from sqlalchemy import exc
+import app.service.event as event_service
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ def summary() -> SummaryDTO:
         n_collections = collection_service.count()
         n_families = family_service.count()
         n_documents = document_service.count()
-        n_events = 0
+        n_events = event_service.count()
 
         return SummaryDTO(
             n_documents=n_documents,

--- a/app/service/event.py
+++ b/app/service/event.py
@@ -1,0 +1,88 @@
+import logging
+from typing import Optional
+
+from pydantic import ConfigDict, validate_call
+from sqlalchemy import exc
+
+import app.clients.db.session as db_session
+import app.repository.event as event_repo
+from app.errors import RepositoryError
+from app.model.event import EventReadDTO
+from app.service import id
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def get(import_id: str) -> Optional[EventReadDTO]:
+    """
+    Gets a family event given the import_id.
+
+    :param str import_id: The import_id to use to get the event.
+    :raises RepositoryError: raised on a database error.
+    :raises ValidationError: raised should the import_id be invalid.
+    :return Optional[EventReadDTO]: The event found or None.
+    """
+    validate_import_id(import_id)
+    try:
+        with db_session.get_db() as db:
+            return event_repo.get(db, import_id)
+    except exc.SQLAlchemyError as e:
+        _LOGGER.error(e)
+        raise RepositoryError(str(e))
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def all() -> list[EventReadDTO]:
+    """
+    Gets the entire list of family events from the repository.
+
+    :return list[EventReadDTO]: The list of family events.
+    """
+    with db_session.get_db() as db:
+        return event_repo.all(db)
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def search(search_term: str) -> list[EventReadDTO]:
+    """
+    Search for all family events that match a search term.
+
+    Specifically searches the event title and event type name for the
+    search term.
+
+    :param str search_term: Search pattern to match.
+    :return list[EventReadDTO]: The list of events that match the search
+        term.
+    """
+    with db_session.get_db() as db:
+        return event_repo.search(db, search_term)
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def validate_import_id(import_id: str) -> None:
+    """
+    Validates the import id for a event.
+
+    TODO: add more validation
+
+    :param str import_id: import id to check.
+    :raises ValidationError: raised should the import_id be invalid.
+    """
+    id.validate(import_id)
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def count() -> Optional[int]:
+    """
+    Gets a count of events from the repository.
+
+    :return Optional[int]: A count of events in the repository or none.
+    """
+    try:
+        with db_session.get_db() as db:
+            return event_repo.count(db)
+    except exc.SQLAlchemyError as e:
+        _LOGGER.error(e)
+        raise RepositoryError(str(e))

--- a/app/service/event.py
+++ b/app/service/event.py
@@ -45,7 +45,7 @@ def all() -> list[EventReadDTO]:
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def search(search_term: str) -> list[EventReadDTO]:
+def search(search_term: str) -> Optional[list[EventReadDTO]]:
     """
     Search for all family events that match a search term.
 
@@ -53,8 +53,8 @@ def search(search_term: str) -> list[EventReadDTO]:
     search term.
 
     :param str search_term: Search pattern to match.
-    :return list[EventReadDTO]: The list of events that match the search
-        term.
+    :return Optional[list[EventReadDTO]] The list of events that match
+        the search term or none.
     """
     with db_session.get_db() as db:
         return event_repo.search(db, search_term)

--- a/integration_tests/analytics/test_get.py
+++ b/integration_tests/analytics/test_get.py
@@ -44,7 +44,6 @@ def test_get_analytics_summary(client: TestClient, test_db: Session, user_header
     assert type(data) is dict
     assert list(data.keys()) == EXPECTED_ANALYTICS_SUMMARY_KEYS
 
-    assert data["n_events"] == 0
     assert dict(sorted(data.items())) == dict(
         sorted(EXPECTED_ANALYTICS_SUMMARY.items())
     )
@@ -64,7 +63,6 @@ def test_get_analytics_summary_when_not_found(
     client: TestClient, test_db: Session, collection_count_none, user_header_token
 ):
     setup_db(test_db, configure_empty=True)
-    # setup_db(test_db)
     response = client.get(
         "/api/v1/analytics/summary",
         headers=user_header_token,

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,13 +1,17 @@
-from typing import Dict
 import uuid
-from fastapi.testclient import TestClient
+from typing import Dict
+
 import pytest
+from fastapi.testclient import TestClient
 from app.config import SQLALCHEMY_DATABASE_URI
 from sqlalchemy_utils import create_database, database_exists, drop_database
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 import app.clients.db.session as db_session
+import app.service.token as token_service
 from app.main import app
+from app.repository import family_repo, collection_repo, document_repo, event_repo
 from integration_tests.mocks.bad_family_repo import (
     mock_bad_family_repo,
     mock_family_count_none,
@@ -20,6 +24,10 @@ from integration_tests.mocks.bad_document_repo import (
     mock_bad_document_repo,
     mock_document_count_none,
 )
+from integration_tests.mocks.bad_event_repo import (
+    mock_bad_event_repo,
+    mock_event_count_none,
+)
 from integration_tests.mocks.rollback_collection_repo import (
     mock_rollback_collection_repo,
 )
@@ -27,8 +35,6 @@ from integration_tests.mocks.rollback_document_repo import (
     mock_rollback_document_repo,
 )
 from integration_tests.mocks.rollback_family_repo import mock_rollback_family_repo
-import app.service.token as token_service
-from app.repository import family_repo, collection_repo, document_repo
 
 
 def get_test_db_url() -> str:
@@ -98,12 +104,11 @@ def bad_document_repo(monkeypatch, mocker):
     yield document_repo
 
 
-# @pytest.fixture
-# def collection_count_none(monkeypatch, mocker):
-#     """Mocks the service for a single test."""
-#     mock_document_count_none(document_repo, monkeypatch, mocker)
-#     mock_family_count_none(family_repo, monkeypatch, mocker)
-#     mock_collection_count_none(collection_repo, monkeypatch, mocker)
+@pytest.fixture
+def bad_event_repo(monkeypatch, mocker):
+    """Mocks the repository for a single test."""
+    mock_bad_event_repo(event_repo, monkeypatch, mocker)
+    yield event_repo
 
 
 @pytest.fixture
@@ -125,6 +130,13 @@ def document_count_none(monkeypatch, mocker):
     """Mocks the service for a single test."""
     mock_document_count_none(document_repo, monkeypatch, mocker)
     yield document_repo
+
+
+@pytest.fixture
+def event_count_none(monkeypatch, mocker):
+    """Mocks the service for a single test."""
+    mock_event_count_none(event_repo, monkeypatch, mocker)
+    yield event_repo
 
 
 @pytest.fixture

--- a/integration_tests/event/test_get.py
+++ b/integration_tests/event/test_get.py
@@ -1,0 +1,100 @@
+from fastapi.testclient import TestClient
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from integration_tests.setup_db import EXPECTED_EVENTS, setup_db
+
+
+# --- GET ALL
+
+
+def test_get_all_events(client: TestClient, test_db: Session, user_header_token):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert type(data) is list
+    assert len(data) == 3
+    ids_found = set([f["import_id"] for f in data])
+    expected_ids = set(["E.0.0.1", "E.0.0.2", "E.0.0.3"])
+
+    assert ids_found.symmetric_difference(expected_ids) == set([])
+
+    sdata = sorted(data, key=lambda d: d["import_id"])
+    assert sdata[0] == EXPECTED_EVENTS[0]
+    assert sdata[1] == EXPECTED_EVENTS[1]
+    assert sdata[2] == EXPECTED_EVENTS[2]
+
+
+def test_get_all_events_when_not_authenticated(client: TestClient, test_db: Session):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# --- GET
+
+
+def test_get_event(client: TestClient, test_db: Session, user_header_token):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/E.0.0.1",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["import_id"] == "E.0.0.1"
+    assert data == EXPECTED_EVENTS[0]
+
+
+def test_get_event_when_not_authenticated(client: TestClient, test_db: Session):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/E.0.0.1",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_event_when_not_found(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/E.0.0.8",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert data["detail"] == "Event not found: E.0.0.8"
+
+
+def test_get_event_when_id_invalid(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/E008",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    data = response.json()
+    expected_msg = "The import id E008 is invalid!"
+    assert data["detail"] == expected_msg
+
+
+def test_get_event_when_db_error(
+    client: TestClient, test_db: Session, bad_event_repo, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/A.0.0.8",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["detail"] == "Bad Repo"

--- a/integration_tests/event/test_search.py
+++ b/integration_tests/event/test_search.py
@@ -1,0 +1,54 @@
+from fastapi.testclient import TestClient
+from fastapi import status
+from sqlalchemy.orm import Session
+from integration_tests.setup_db import setup_db
+
+
+def test_search_event(client: TestClient, test_db: Session, user_header_token):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/?q=Amended",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert type(data) is list
+
+    ids_found = set([f["import_id"] for f in data])
+    assert len(ids_found) == 2
+
+    expected_ids = set(["E.0.0.2", "E.0.0.3"])
+    assert ids_found.symmetric_difference(expected_ids) == set([])
+
+
+def test_search_event_when_not_authorised(client: TestClient, test_db: Session):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/?q=cabbages",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_search_event_when_nothing_found(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/?q=lemon",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert data["detail"] == "Events not found for term: lemon"
+
+
+def test_search_event_when_db_error(
+    client: TestClient, test_db: Session, bad_event_repo, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/?q=lemon",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert bad_event_repo.search.call_count == 1

--- a/integration_tests/mocks/bad_event_repo.py
+++ b/integration_tests/mocks/bad_event_repo.py
@@ -1,0 +1,39 @@
+from typing import Optional
+from pytest import MonkeyPatch
+from app.errors import RepositoryError
+
+from app.model.event import EventReadDTO
+
+
+def mock_bad_event_repo(repo, monkeypatch: MonkeyPatch, mocker):
+    def mock_get_all(_):
+        raise RepositoryError("Bad Repo")
+
+    def mock_get(_, import_id: str) -> Optional[EventReadDTO]:
+        raise RepositoryError("Bad Repo")
+
+    def mock_search(_, q: str) -> list[EventReadDTO]:
+        raise RepositoryError("Bad Repo")
+
+    def mock_get_count(_) -> Optional[int]:
+        raise RepositoryError("Bad Repo")
+
+    monkeypatch.setattr(repo, "get", mock_get)
+    mocker.spy(repo, "get")
+
+    monkeypatch.setattr(repo, "all", mock_get_all)
+    mocker.spy(repo, "all")
+
+    monkeypatch.setattr(repo, "search", mock_search)
+    mocker.spy(repo, "search")
+
+    monkeypatch.setattr(repo, "count", mock_get_count)
+    mocker.spy(repo, "count")
+
+
+def mock_event_count_none(repo, monkeypatch: MonkeyPatch, mocker):
+    def mock_get_count(_) -> Optional[int]:
+        return None
+
+    monkeypatch.setattr(repo, "count", mock_get_count)
+    mocker.spy(repo, "count")

--- a/integration_tests/setup_db.py
+++ b/integration_tests/setup_db.py
@@ -346,6 +346,11 @@ def _setup_event_data(
     family_id: str,
     configure_empty: bool = False,
 ) -> None:
+    """
+    TODO: Need to test events associated with a family document.
+
+    family_document_import_id=data["family_document_import_id"],
+    """
     if configure_empty is True:
         return None
 
@@ -357,7 +362,6 @@ def _setup_event_data(
             date=data["date"],
             event_type_name=data["event_type_value"],
             family_import_id=data["family_import_id"],
-            # family_document_import_id=data["family_document_import_id"],
             status=data["event_status"],
         )
         test_db.add(fe)

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -17,6 +17,7 @@ import app.service.document as document_service
 import app.service.config as config_service
 import app.service.token as token_service
 import app.service.analytics as analytics_service
+import app.service.event as event_service
 from app.repository import (
     family_repo,
     geography_repo,
@@ -26,6 +27,7 @@ from app.repository import (
     app_user_repo,
     config_repo,
     document_repo,
+    event_repo,
 )
 
 from unit_tests.mocks.repos.app_user_repo import mock_app_user_repo
@@ -36,12 +38,14 @@ from unit_tests.mocks.repos.geography_repo import mock_geography_repo
 from unit_tests.mocks.repos.metadata_repo import mock_metadata_repo
 from unit_tests.mocks.repos.organisation_repo import mock_organisation_repo
 from unit_tests.mocks.repos.config_repo import mock_config_repo
+from unit_tests.mocks.repos.event_repo import mock_event_repo
 
 from unit_tests.mocks.services.family_service import mock_family_service
 from unit_tests.mocks.services.collection_service import mock_collection_service
 from unit_tests.mocks.services.document_service import mock_document_service
 from unit_tests.mocks.services.config_service import mock_config_service
 from unit_tests.mocks.services.analytics_service import mock_analytics_service
+from unit_tests.mocks.services.event_service import mock_event_service
 
 
 @pytest.fixture
@@ -110,6 +114,13 @@ def config_repo_mock(monkeypatch, mocker):
     yield config_repo
 
 
+@pytest.fixture
+def event_repo_mock(monkeypatch, mocker):
+    """Mocks the repository for a single test."""
+    mock_event_repo(event_repo, monkeypatch, mocker)
+    yield event_repo
+
+
 # ----- Mock services
 
 
@@ -146,6 +157,13 @@ def analytics_service_mock(monkeypatch, mocker):
     """Mocks the service for a single test."""
     mock_analytics_service(analytics_service, monkeypatch, mocker)
     yield analytics_service
+
+
+@pytest.fixture
+def event_service_mock(monkeypatch, mocker):
+    """Mocks the service for a single test."""
+    mock_event_service(event_service, monkeypatch, mocker)
+    yield event_service
 
 
 # ----- User tokens

--- a/unit_tests/helpers/analytics.py
+++ b/unit_tests/helpers/analytics.py
@@ -5,14 +5,14 @@ from app.model.analytics import SummaryDTO
 EXPECTED_NUM_DOCUMENTS = 33
 EXPECTED_NUM_FAMILIES = 22
 EXPECTED_NUM_COLLECTIONS = 11
-EXPECTED_NUM_EVENTS = 0
+EXPECTED_NUM_EVENTS = 5
 
 
 def create_summary_dto(
     n_documents: Optional[int],
     n_families: Optional[int],
     n_collections: Optional[int],
-    n_events: Optional[int] = 0,
+    n_events: Optional[int],
 ) -> SummaryDTO:
     return SummaryDTO(
         n_documents=n_documents,

--- a/unit_tests/helpers/event.py
+++ b/unit_tests/helpers/event.py
@@ -1,0 +1,17 @@
+from app.clients.db.models.law_policy.family import EventStatus
+from app.model.event import EventReadDTO
+from datetime import datetime, timezone
+
+
+def create_event_read_dto(
+    import_id: str, family_import_id: str = "family_import_id", title: str = "title"
+) -> EventReadDTO:
+    return EventReadDTO(
+        import_id=import_id,
+        event_title=title,
+        date=datetime.now(timezone.utc),
+        event_type_value="Some Event",
+        family_import_id=family_import_id,
+        family_document_import_id=None,
+        event_status=EventStatus.OK,
+    )

--- a/unit_tests/mocks/repos/document_repo.py
+++ b/unit_tests/mocks/repos/document_repo.py
@@ -46,7 +46,7 @@ def mock_document_repo(document_repo, monkeypatch: MonkeyPatch, mocker):
     def mock_delete(_, import_id: str) -> bool:
         maybe_throw()
         return not document_repo.return_empty
-    
+
     def mock_get_count(_) -> Optional[int]:
         maybe_throw()
         if not document_repo.return_empty:
@@ -70,6 +70,6 @@ def mock_document_repo(document_repo, monkeypatch: MonkeyPatch, mocker):
 
     monkeypatch.setattr(document_repo, "delete", mock_delete)
     mocker.spy(document_repo, "delete")
-    
+
     monkeypatch.setattr(document_repo, "count", mock_get_count)
     mocker.spy(document_repo, "count")

--- a/unit_tests/mocks/repos/event_repo.py
+++ b/unit_tests/mocks/repos/event_repo.py
@@ -1,0 +1,50 @@
+from typing import Optional
+from pytest import MonkeyPatch
+
+from sqlalchemy import exc
+from app.model.event import EventReadDTO
+from unit_tests.helpers.event import create_event_read_dto
+
+
+def mock_event_repo(event_repo, monkeypatch: MonkeyPatch, mocker):
+    event_repo.return_empty = False
+    event_repo.throw_repository_error = False
+
+    def maybe_throw():
+        if event_repo.throw_repository_error:
+            raise exc.SQLAlchemyError("bad repo")
+
+    def mock_get_all(_) -> list[EventReadDTO]:
+        values = []
+        for x in range(3):
+            dto = create_event_read_dto(import_id=f"id{x}")
+            values.append(dto)
+        return values
+
+    def mock_get(_, import_id: str) -> Optional[EventReadDTO]:
+        dto = create_event_read_dto(import_id)
+        return dto
+
+    def mock_search(_, q: str) -> list[EventReadDTO]:
+        maybe_throw()
+        if not event_repo.return_empty:
+            return [create_event_read_dto("search1")]
+        return []
+
+    def mock_get_count(_) -> Optional[int]:
+        maybe_throw()
+        if not event_repo.return_empty:
+            return 5
+        return
+
+    monkeypatch.setattr(event_repo, "get", mock_get)
+    mocker.spy(event_repo, "get")
+
+    monkeypatch.setattr(event_repo, "all", mock_get_all)
+    mocker.spy(event_repo, "all")
+
+    monkeypatch.setattr(event_repo, "search", mock_search)
+    mocker.spy(event_repo, "search")
+
+    monkeypatch.setattr(event_repo, "count", mock_get_count)
+    mocker.spy(event_repo, "count")

--- a/unit_tests/mocks/services/analytics_service.py
+++ b/unit_tests/mocks/services/analytics_service.py
@@ -20,14 +20,14 @@ def mock_analytics_service(analytics_service, monkeypatch: MonkeyPatch, mocker):
                 n_documents=33,
                 n_families=22,
                 n_collections=None,
-                n_events=0,
+                n_events=5,
             )
 
         return create_summary_dto(
             n_documents=33,
             n_families=22,
             n_collections=11,
-            n_events=0,
+            n_events=5,
         )
 
     monkeypatch.setattr(analytics_service, "summary", mock_get_summary)

--- a/unit_tests/mocks/services/event_service.py
+++ b/unit_tests/mocks/services/event_service.py
@@ -34,7 +34,7 @@ def mock_event_service(event_service, monkeypatch: MonkeyPatch, mocker):
         maybe_throw()
         if event_service.missing:
             return None
-        return 33
+        return 5
 
     monkeypatch.setattr(event_service, "get", mock_get_document)
     mocker.spy(event_service, "get")

--- a/unit_tests/mocks/services/event_service.py
+++ b/unit_tests/mocks/services/event_service.py
@@ -1,0 +1,49 @@
+from typing import Optional
+from pytest import MonkeyPatch
+from app.errors import RepositoryError
+
+from app.model.event import EventReadDTO
+from unit_tests.helpers.event import create_event_read_dto
+
+
+def mock_event_service(event_service, monkeypatch: MonkeyPatch, mocker):
+    event_service.missing = False
+    event_service.throw_repository_error = False
+
+    def maybe_throw():
+        if event_service.throw_repository_error:
+            raise RepositoryError("bad repo")
+
+    def mock_get_all_documents() -> list[EventReadDTO]:
+        maybe_throw()
+        return [create_event_read_dto("test")]
+
+    def mock_get_document(import_id: str) -> Optional[EventReadDTO]:
+        maybe_throw()
+        if not event_service.missing:
+            return create_event_read_dto(import_id)
+
+    def mock_search_documents(q: str) -> list[EventReadDTO]:
+        maybe_throw()
+        if event_service.missing:
+            return []
+        else:
+            return [create_event_read_dto("search1")]
+
+    def mock_count_collection() -> Optional[int]:
+        maybe_throw()
+        if event_service.missing:
+            return None
+        return 33
+
+    monkeypatch.setattr(event_service, "get", mock_get_document)
+    mocker.spy(event_service, "get")
+
+    monkeypatch.setattr(event_service, "all", mock_get_all_documents)
+    mocker.spy(event_service, "all")
+
+    monkeypatch.setattr(event_service, "search", mock_search_documents)
+    mocker.spy(event_service, "search")
+
+    monkeypatch.setattr(event_service, "count", mock_count_collection)
+    mocker.spy(event_service, "count")

--- a/unit_tests/routers/test_analytics.py
+++ b/unit_tests/routers/test_analytics.py
@@ -13,7 +13,6 @@ def test_get_all_when_ok(client: TestClient, analytics_service_mock, user_header
     data = response.json()
     assert type(data) is dict
     assert len(data) == 4
-    assert data["n_events"] == 0
     assert analytics_service_mock.summary.call_count == 1
 
 
@@ -21,7 +20,8 @@ def test_get_when_ok(client: TestClient, analytics_service_mock, user_header_tok
     response = client.get("/api/v1/analytics/summary", headers=user_header_token)
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert data["n_events"] == 0
+    assert type(data) is dict
+    assert len(data) == 4
     assert analytics_service_mock.summary.call_count == 1
 
 

--- a/unit_tests/routers/test_event.py
+++ b/unit_tests/routers/test_event.py
@@ -1,0 +1,51 @@
+from fastapi import status
+from fastapi.testclient import TestClient
+import app.service.event as event_service
+
+
+def test_get_all_when_ok(client: TestClient, user_header_token, event_service_mock):
+    response = client.get("/api/v1/events", headers=user_header_token)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert type(data) is list
+    assert len(data) > 0
+    assert data[0]["import_id"] == "test"
+    assert event_service.all.call_count == 1
+
+
+def test_get_when_ok(client: TestClient, event_service_mock, user_header_token):
+    response = client.get("/api/v1/events/import_id", headers=user_header_token)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["import_id"] == "import_id"
+    assert event_service_mock.get.call_count == 1
+
+
+def test_get_when_not_found(client: TestClient, event_service_mock, user_header_token):
+    event_service_mock.missing = True
+    response = client.get("/api/v1/events/event1", headers=user_header_token)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert data["detail"] == "Event not found: event1"
+    assert event_service_mock.get.call_count == 1
+
+
+def test_search_when_ok(client: TestClient, event_service_mock, user_header_token):
+    response = client.get("/api/v1/events/?q=anything", headers=user_header_token)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert type(data) is list
+    assert len(data) > 0
+    assert data[0]["import_id"] == "search1"
+    assert event_service_mock.search.call_count == 1
+
+
+def test_search_when_not_found(
+    client: TestClient, event_service_mock, user_header_token
+):
+    event_service_mock.missing = True
+    response = client.get("/api/v1/events/?q=stuff", headers=user_header_token)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert data["detail"] == "Events not found for term: stuff"
+    assert event_service_mock.search.call_count == 1

--- a/unit_tests/service/test_analytics_service.py
+++ b/unit_tests/service/test_analytics_service.py
@@ -1,9 +1,10 @@
 from typing import Optional
+
 import pytest
+
 from app.errors import RepositoryError
 from app.model.analytics import SummaryDTO
 import app.service.analytics as analytics_service
-from sqlalchemy import exc
 
 from unit_tests.helpers.analytics import (
     create_summary_dto,
@@ -31,21 +32,23 @@ def expected_analytics_summary(
 # --- GET SUMMARY
 
 
-def test_summary(collection_repo_mock, document_repo_mock, family_repo_mock):
+def test_summary(
+    collection_repo_mock, document_repo_mock, family_repo_mock, event_repo_mock
+):
     result = analytics_service.summary()
     assert result == expected_analytics_summary()
 
     assert result is not None
-    assert result.n_events == 0
 
     # Ensure the analytics service uses the other services to validate.
     assert collection_repo_mock.count.call_count == 1
     assert document_repo_mock.count.call_count == 1
     assert family_repo_mock.count.call_count == 1
+    assert event_repo_mock.count.call_count == 1
 
 
 def test_summary_returns_none(
-    collection_repo_mock, document_repo_mock, family_repo_mock
+    collection_repo_mock, document_repo_mock, family_repo_mock, event_repo_mock
 ):
     collection_repo_mock.return_empty = True
     result = analytics_service.summary()
@@ -55,16 +58,18 @@ def test_summary_returns_none(
     assert collection_repo_mock.count.call_count == 1
     assert document_repo_mock.count.call_count == 1
     assert family_repo_mock.count.call_count == 1
+    assert event_repo_mock.count.call_count == 1
 
 
 def test_summary_raises_if_db_error(
-    collection_repo_mock, document_repo_mock, family_repo_mock
+    collection_repo_mock, document_repo_mock, family_repo_mock, event_repo_mock
 ):
     collection_repo_mock.throw_repository_error = True
-    with pytest.raises(RepositoryError) as e:
+    with pytest.raises(RepositoryError):
         analytics_service.summary()
 
     # Ensure the analytics service uses the other services to validate.
     assert collection_repo_mock.count.call_count == 1
     assert document_repo_mock.count.call_count == 0
     assert family_repo_mock.count.call_count == 0
+    assert event_repo_mock.count.call_count == 0

--- a/unit_tests/service/test_event_service.py
+++ b/unit_tests/service/test_event_service.py
@@ -1,0 +1,72 @@
+import pytest
+import app.service.event as event_service
+from app.errors import RepositoryError, ValidationError
+
+
+# --- GET
+
+
+def test_get(event_repo_mock):
+    result = event_service.get("id.1.2.3")
+    assert result is not None
+    assert result.import_id == "id.1.2.3"
+    assert event_repo_mock.get.call_count == 1
+
+
+def test_get_returns_none(event_repo_mock):
+    event_repo_mock.return_empty = True
+    result = event_service.get("id.1.2.3")
+    assert result is not None
+    assert event_repo_mock.get.call_count == 1
+
+
+def test_get_raises_when_invalid_id(event_repo_mock):
+    with pytest.raises(ValidationError) as e:
+        event_service.get("a.b.c")
+    expected_msg = "The import id a.b.c is invalid!"
+    assert e.value.message == expected_msg
+    assert event_repo_mock.get.call_count == 0
+
+
+# --- SEARCH
+
+
+def test_search(event_repo_mock):
+    result = event_service.search("two")
+    assert result is not None
+    assert len(result) == 1
+    assert event_repo_mock.search.call_count == 1
+
+
+def test_search_when_missing(event_repo_mock):
+    event_repo_mock.return_empty = True
+    result = event_service.search("empty")
+    assert result is not None
+    assert len(result) == 0
+    assert event_repo_mock.search.call_count == 1
+
+
+# --- COUNT
+
+
+def test_count(event_repo_mock):
+    result = event_service.count()
+    assert result is not None
+    assert event_repo_mock.count.call_count == 1
+
+
+def test_count_returns_none(event_repo_mock):
+    event_repo_mock.return_empty = True
+    result = event_service.count()
+    assert result is None
+    assert event_repo_mock.count.call_count == 1
+
+
+def test_count_raises_if_db_error(event_repo_mock):
+    event_repo_mock.throw_repository_error = True
+    with pytest.raises(RepositoryError) as e:
+        event_service.count()
+
+    expected_msg = "bad repo"
+    assert e.value.message == expected_msg
+    assert event_repo_mock.count.call_count == 1


### PR DESCRIPTION
# Description

Please include:
- Added event router
- Added get, all, search, and count service and repo for family events
- Added family events get, search, all endpoints to events router
- Unit and integration tests for the above

[Link to Linear ticket](https://linear.app/climate-policy-radar/issue/PDCT-310/endpoint-for-getsearch-events)

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit and integration tests included.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
