### PR TITLE
PDCT-311 Added endpoint and tests for updating family events.

### DIFF
--- a/app/api/api_v1/routers/event.py
+++ b/app/api/api_v1/routers/event.py
@@ -133,7 +133,6 @@ async def update_event(
     :raises HTTPException: If the event is not found a 404 is returned.
     :return EventDTO: returns a EventDTO of the event updated.
     """
-    _LOGGER.warning("hit update event endpoint")
     try:
         event = event_service.update(import_id, new_event)
     except ValidationError as e:

--- a/app/api/api_v1/routers/event.py
+++ b/app/api/api_v1/routers/event.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, status
 
 import app.service.event as event_service
 from app.errors import RepositoryError, ValidationError
-from app.model.event import EventCreateDTO, EventReadDTO
+from app.model.event import EventCreateDTO, EventReadDTO, EventWriteDTO
 
 event_router = r = APIRouter()
 
@@ -92,7 +92,7 @@ async def get_event(import_id: str) -> EventReadDTO:
 
 
 @r.post("/events", response_model=str, status_code=status.HTTP_201_CREATED)
-async def create_document(
+async def create_event(
     new_event: EventCreateDTO,
 ) -> str:
     """
@@ -116,3 +116,35 @@ async def create_document(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message
         )
+
+
+@r.put(
+    "/events/{import_id}",
+    response_model=EventReadDTO,
+)
+async def update_event(
+    import_id: str,
+    new_event: EventWriteDTO,
+) -> EventReadDTO:
+    """
+    Updates a specific event given the import id.
+
+    :param str import_id: Specified import_id.
+    :raises HTTPException: If the event is not found a 404 is returned.
+    :return EventDTO: returns a EventDTO of the event updated.
+    """
+    _LOGGER.warning("hit update event endpoint")
+    try:
+        event = event_service.update(import_id, new_event)
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
+    except RepositoryError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message
+        )
+
+    if event is None:
+        detail = f"Event not updated: {import_id}"
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+    return event

--- a/app/model/event.py
+++ b/app/model/event.py
@@ -2,9 +2,7 @@ from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel
 
-from app.clients.db.models.law_policy.family import (
-    EventStatus,
-)
+from app.clients.db.models.law_policy.family import EventStatus
 
 
 class EventReadDTO(BaseModel):
@@ -44,3 +42,19 @@ class EventCreateDTO(BaseModel):
     # From FamilyDocument
     family_import_id: str
     family_document_import_id: Optional[str] = None
+
+
+class EventWriteDTO(BaseModel):
+    """
+    JSON Representation of the DTO for writing an event.
+
+    The following fields are immutable:
+    - family_import_id
+    - import_id
+    - family_document_import_id
+    - event_status
+    """
+
+    event_title: str
+    date: datetime
+    event_type_value: str

--- a/app/repository/event.py
+++ b/app/repository/event.py
@@ -108,7 +108,6 @@ def get(db: Session, import_id: str) -> Optional[EventReadDTO]:
     except NoResultFound as e:
         _LOGGER.error(e)
         return
-    _LOGGER.warning(_event_to_dto(family_event_meta))
     return _event_to_dto(family_event_meta)
 
 
@@ -181,9 +180,7 @@ def update(db: Session, import_id: str, event: EventWriteDTO) -> bool:
     :param DocumentDTO event: The new values
     :return bool: True if new values were set otherwise false.
     """
-    _LOGGER.warning("hit update event repo")
     new_values = event.model_dump()
-    _LOGGER.warning(f"new_values: {new_values['date']}")
 
     original_fe = (
         db.query(FamilyEvent).filter(FamilyEvent.import_id == import_id).one_or_none()
@@ -192,9 +189,6 @@ def update(db: Session, import_id: str, event: EventWriteDTO) -> bool:
     if original_fe is None:  # Not found the event to update
         _LOGGER.error(f"Unable to find event for update {import_id}")
         return False
-
-    _LOGGER.warning(f"date: {original_fe.date}")
-    # update_slug = original_pd.title != new_values["title"]
 
     result = db.execute(
         db_update(FamilyEvent)

--- a/app/service/event.py
+++ b/app/service/event.py
@@ -111,11 +111,7 @@ def update(
     :raises ValidationError: raised should the import_id be invalid.
     :return Optional[EventReadDTO]: The updated event or None if not updated.
     """
-    _LOGGER.warning("hit update event service")
     validate_import_id(import_id)
-
-    # TODO: implement changing of a event's organisation
-    # org_id = organisation.get_id(db, event.organisation)
 
     try:
         if event_repo.update(db, import_id, event):

--- a/integration_tests/event/test_update.py
+++ b/integration_tests/event/test_update.py
@@ -1,0 +1,152 @@
+from datetime import datetime, timezone
+from fastapi.encoders import jsonable_encoder
+from fastapi.testclient import TestClient
+from fastapi import status
+from sqlalchemy.orm import Session
+from app.clients.db.models.law_policy.family import EventStatus
+
+from app.clients.db.models.law_policy import FamilyEvent
+
+from integration_tests.setup_db import EXPECTED_EVENTS, setup_db
+from unit_tests.helpers.event import create_event_write_dto
+
+
+def _get_event_tuple(test_db: Session, import_id: str) -> FamilyEvent:
+    fe: FamilyEvent = (
+        test_db.query(FamilyEvent).filter(FamilyEvent.import_id == import_id).one()
+    )
+    assert fe is not None
+    return fe
+
+
+def test_update_event(client: TestClient, test_db: Session, user_header_token):
+    setup_db(test_db)
+    new_event = create_event_write_dto(title="Updated Title")
+    response = client.put(
+        "/api/v1/events/E.0.0.2",
+        json=jsonable_encoder(new_event),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    # Check the properties and values of the EventReadDTO object we return to the
+    # client.
+    assert data["event_type_value"] == "Amended"
+    assert data["event_title"] == "Updated Title"
+    assert isinstance(data["date"], str) is True
+    assert data["date"] == "2023-01-01T00:00:00Z"
+
+    # Get the record in the FamilyEvent table we want to update in the database and
+    # check the types of the values are correct and that the values have been
+    # successfully updated.
+    fe = _get_event_tuple(test_db, "E.0.0.2")
+    assert isinstance(fe.date, datetime) is True
+    assert isinstance(fe.status, EventStatus) is True
+    assert (
+        isinstance(fe.family_document_import_id, str) is True
+        or fe.family_document_import_id is None
+    )
+    assert (
+        all(
+            isinstance(x, str)
+            for x in [
+                fe.import_id,
+                fe.family_import_id,
+                fe.event_type_name,
+                fe.title,
+            ]
+        )
+        is True
+    )
+    assert fe.import_id == "E.0.0.2"
+    assert fe.event_type_name == "Amended"
+    assert fe.date == datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+    assert fe.title == "Updated Title"
+    assert fe.family_import_id == "A.0.0.1"
+    assert fe.family_document_import_id is None
+    assert fe.status == EventStatus.OK
+
+
+def test_update_event_when_not_authorised(client: TestClient, test_db: Session):
+    setup_db(test_db)
+    new_event = create_event_write_dto(
+        title="Updated Title",
+    )
+    response = client.put("/api/v1/events/E.0.0.2", json=jsonable_encoder(new_event))
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_update_event_idempotent(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    event = EXPECTED_EVENTS[1]
+    response = client.put(
+        f"/api/v1/events/{event['import_id']}",
+        json=event,
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    assert data["event_title"] == EXPECTED_EVENTS[1]["event_title"]
+
+    fe = _get_event_tuple(test_db, EXPECTED_EVENTS[1]["import_id"])
+    assert fe.title == EXPECTED_EVENTS[1]["event_title"]
+
+
+def test_update_event_rollback(
+    client: TestClient, test_db: Session, rollback_event_repo, user_header_token
+):
+    setup_db(test_db)
+    new_event = create_event_write_dto(
+        title="Updated Title",
+    )
+    response = client.put(
+        "/api/v1/events/E.0.0.2",
+        json=jsonable_encoder(new_event),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+    pd = _get_event_tuple(test_db, "E.0.0.2")
+    assert pd.title != "Updated Title"
+
+    assert rollback_event_repo.update.call_count == 1
+
+
+def test_update_event_when_not_found(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    new_event = create_event_write_dto(
+        title="Updated Title",
+    )
+    response = client.put(
+        "/api/v1/events/E.0.0.22",
+        json=jsonable_encoder(new_event),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert data["detail"] == "Event not updated: E.0.0.22"
+
+
+def test_update_event_when_db_error(
+    client: TestClient, test_db: Session, bad_event_repo, user_header_token
+):
+    setup_db(test_db)
+
+    new_event = create_event_write_dto(
+        title="Updated Title",
+    )
+    response = client.put(
+        "/api/v1/events/E.0.0.2",
+        json=jsonable_encoder(new_event),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["detail"] == "Bad Repo"
+    assert bad_event_repo.update.call_count == 1

--- a/integration_tests/mocks/bad_event_repo.py
+++ b/integration_tests/mocks/bad_event_repo.py
@@ -18,6 +18,9 @@ def mock_bad_event_repo(repo, monkeypatch: MonkeyPatch, mocker):
     def mock_create(_, data: EventCreateDTO) -> Optional[EventReadDTO]:
         raise RepositoryError("Bad Repo")
 
+    def mock_update(_, import_id, data: EventReadDTO) -> Optional[EventReadDTO]:
+        raise RepositoryError("Bad Repo")
+
     def mock_get_count(_) -> Optional[int]:
         raise RepositoryError("Bad Repo")
 
@@ -32,6 +35,9 @@ def mock_bad_event_repo(repo, monkeypatch: MonkeyPatch, mocker):
 
     monkeypatch.setattr(repo, "create", mock_create)
     mocker.spy(repo, "create")
+
+    monkeypatch.setattr(repo, "update", mock_update)
+    mocker.spy(repo, "update")
 
     monkeypatch.setattr(repo, "count", mock_get_count)
     mocker.spy(repo, "count")

--- a/integration_tests/mocks/rollback_event_repo.py
+++ b/integration_tests/mocks/rollback_event_repo.py
@@ -3,15 +3,23 @@ from pytest import MonkeyPatch
 
 from sqlalchemy.exc import NoResultFound
 
-from app.model.event import EventCreateDTO, EventReadDTO
+from app.model.event import EventCreateDTO, EventReadDTO, EventWriteDTO
 
 
 def mock_rollback_event_repo(event_repo, monkeypatch: MonkeyPatch, mocker):
     actual_create = event_repo.create
+    actual_update = event_repo.update
 
-    def mock_create_document(db, data: EventCreateDTO) -> Optional[EventReadDTO]:
+    def mock_create_event(db, data: EventCreateDTO) -> Optional[EventReadDTO]:
         actual_create(db, data)
         raise NoResultFound()
 
-    monkeypatch.setattr(event_repo, "create", mock_create_document)
+    def mock_update_event(db, import_id: str, data: EventWriteDTO) -> EventReadDTO:
+        actual_update(db, import_id, data)
+        raise NoResultFound()
+
+    monkeypatch.setattr(event_repo, "create", mock_create_event)
     mocker.spy(event_repo, "create")
+
+    monkeypatch.setattr(event_repo, "update", mock_update_event)
+    mocker.spy(event_repo, "update")

--- a/unit_tests/helpers/event.py
+++ b/unit_tests/helpers/event.py
@@ -1,5 +1,5 @@
 from app.clients.db.models.law_policy.family import EventStatus
-from app.model.event import EventCreateDTO, EventReadDTO
+from app.model.event import EventCreateDTO, EventReadDTO, EventWriteDTO
 
 from datetime import datetime, timezone
 
@@ -28,4 +28,16 @@ def create_event_create_dto(
         family_import_id=family_import_id,
         family_document_import_id=None,
         event_status=EventStatus.OK,
+    )
+
+
+def create_event_write_dto(
+    title: str = "title",
+    event_type_value: str = "Amended",
+    date: datetime = datetime(2023, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+) -> EventWriteDTO:
+    return EventWriteDTO(
+        event_title=title,
+        date=date,
+        event_type_value=event_type_value,
     )

--- a/unit_tests/mocks/repos/event_repo.py
+++ b/unit_tests/mocks/repos/event_repo.py
@@ -2,7 +2,7 @@ from typing import Optional
 from pytest import MonkeyPatch
 
 from sqlalchemy import exc
-from app.model.event import EventCreateDTO, EventReadDTO
+from app.model.event import EventCreateDTO, EventReadDTO, EventWriteDTO
 from unit_tests.helpers.event import create_event_read_dto
 
 
@@ -37,6 +37,12 @@ def mock_event_repo(event_repo, monkeypatch: MonkeyPatch, mocker):
             raise exc.NoResultFound()
         return "test.new.event.0"
 
+    def mock_update(_, import_id: str, data: EventWriteDTO) -> EventReadDTO:
+        maybe_throw()
+        if event_repo.return_empty:
+            raise exc.NoResultFound()
+        return create_event_read_dto("a.b.c.d")
+
     def mock_get_count(_) -> Optional[int]:
         maybe_throw()
         if not event_repo.return_empty:
@@ -54,6 +60,9 @@ def mock_event_repo(event_repo, monkeypatch: MonkeyPatch, mocker):
 
     monkeypatch.setattr(event_repo, "create", mock_create)
     mocker.spy(event_repo, "create")
+
+    monkeypatch.setattr(event_repo, "update", mock_update)
+    mocker.spy(event_repo, "update")
 
     monkeypatch.setattr(event_repo, "count", mock_get_count)
     mocker.spy(event_repo, "count")

--- a/unit_tests/mocks/services/event_service.py
+++ b/unit_tests/mocks/services/event_service.py
@@ -2,7 +2,7 @@ from typing import Optional
 from pytest import MonkeyPatch
 from app.errors import RepositoryError, ValidationError
 
-from app.model.event import EventCreateDTO, EventReadDTO
+from app.model.event import EventCreateDTO, EventReadDTO, EventWriteDTO
 from unit_tests.helpers.event import create_event_read_dto
 
 
@@ -14,46 +14,58 @@ def mock_event_service(event_service, monkeypatch: MonkeyPatch, mocker):
         if event_service.throw_repository_error:
             raise RepositoryError("bad repo")
 
-    def mock_get_all_documents() -> list[EventReadDTO]:
+    def mock_get_all_events() -> list[EventReadDTO]:
         maybe_throw()
         return [create_event_read_dto("test")]
 
-    def mock_get_document(import_id: str) -> Optional[EventReadDTO]:
+    def mock_get_event(import_id: str) -> Optional[EventReadDTO]:
         maybe_throw()
         if not event_service.missing:
             return create_event_read_dto(import_id)
 
-    def mock_search_documents(q: str) -> list[EventReadDTO]:
+    def mock_search_events(q: str) -> list[EventReadDTO]:
         maybe_throw()
         if event_service.missing:
             return []
         else:
             return [create_event_read_dto("search1")]
 
-    def mock_create_document(data: EventCreateDTO) -> str:
+    def mock_create_event(data: EventCreateDTO) -> str:
         maybe_throw()
         if not event_service.missing:
             return "new.event.id.0"
 
         raise ValidationError(f"Could not find family for {data.family_import_id}")
 
-    def mock_count_collection() -> Optional[int]:
+    def mock_update_event(
+        import_id: str, data: EventWriteDTO
+    ) -> Optional[EventReadDTO]:
+        maybe_throw()
+        if not event_service.missing:
+            return create_event_read_dto(
+                import_id, "family_import_id", data.event_title
+            )
+
+    def mock_count_event() -> Optional[int]:
         maybe_throw()
         if event_service.missing:
             return None
         return 5
 
-    monkeypatch.setattr(event_service, "get", mock_get_document)
+    monkeypatch.setattr(event_service, "get", mock_get_event)
     mocker.spy(event_service, "get")
 
-    monkeypatch.setattr(event_service, "all", mock_get_all_documents)
+    monkeypatch.setattr(event_service, "all", mock_get_all_events)
     mocker.spy(event_service, "all")
 
-    monkeypatch.setattr(event_service, "search", mock_search_documents)
+    monkeypatch.setattr(event_service, "search", mock_search_events)
     mocker.spy(event_service, "search")
 
-    monkeypatch.setattr(event_service, "create", mock_create_document)
+    monkeypatch.setattr(event_service, "create", mock_create_event)
     mocker.spy(event_service, "create")
 
-    monkeypatch.setattr(event_service, "count", mock_count_collection)
+    monkeypatch.setattr(event_service, "update", mock_update_event)
+    mocker.spy(event_service, "update")
+
+    monkeypatch.setattr(event_service, "count", mock_count_event)
     mocker.spy(event_service, "count")

--- a/unit_tests/routers/test_event.py
+++ b/unit_tests/routers/test_event.py
@@ -5,7 +5,7 @@ import app.service.event as event_service
 
 from unit_tests.helpers.event import (
     create_event_create_dto,
-    # create_event_write_dto,
+    create_event_write_dto,
 )
 
 
@@ -80,3 +80,32 @@ def test_create_when_family_not_found(
     data = response.json()
     assert data["detail"] == "Could not find family for this_family"
     assert event_service_mock.create.call_count == 1
+
+
+def test_update_when_ok(client: TestClient, event_service_mock, user_header_token):
+    new_data = create_event_write_dto("event1")
+    response = client.put(
+        "/api/v1/events/E.0.0.1",
+        json=jsonable_encoder(new_data),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["import_id"] == "E.0.0.1"
+    assert event_service_mock.update.call_count == 1
+
+
+def test_update_when_not_found(
+    client: TestClient, event_service_mock, user_header_token
+):
+    event_service_mock.missing = True
+    new_data = create_event_write_dto("event1")
+    response = client.put(
+        "/api/v1/events/a.b.c.d",
+        json=jsonable_encoder(new_data),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert data["detail"] == "Event not updated: a.b.c.d"
+    assert event_service_mock.update.call_count == 1

--- a/unit_tests/service/test_event_service.py
+++ b/unit_tests/service/test_event_service.py
@@ -2,6 +2,16 @@ import pytest
 import app.service.event as event_service
 from app.errors import RepositoryError, ValidationError
 from unit_tests.helpers.event import create_event_create_dto
+from app.model.event import EventReadDTO, EventWriteDTO
+
+
+def _to_write_dto(dto: EventReadDTO) -> EventWriteDTO:
+    return EventWriteDTO(
+        event_title=dto.event_title,
+        date=dto.date,
+        event_type_value=dto.event_type_value,
+    )
+
 
 # --- GET
 
@@ -74,6 +84,47 @@ def test_create_raises_when_invalid_family_id(event_repo_mock):
     expected_msg = f"The import id {new_event.family_import_id} is invalid!"
     assert e.value.message == expected_msg
     assert event_repo_mock.create.call_count == 0
+
+
+# --- UPDATE
+
+
+def test_update(
+    event_repo_mock,
+):
+    event = event_service.get("a.b.c.d")
+    assert event is not None
+
+    result = event_service.update(event.import_id, _to_write_dto(event))
+    assert result is not None
+    assert event_repo_mock.update.call_count == 1
+
+
+def test_update_when_missing(
+    event_repo_mock,
+):
+    event = event_service.get("a.b.c.d")
+    assert event is not None
+    event_repo_mock.return_empty = True
+
+    with pytest.raises(RepositoryError) as e:
+        event_service.update(event.import_id, _to_write_dto(event))
+    assert e.value.message == "Error when updating event a.b.c.d"
+    assert event_repo_mock.update.call_count == 1
+
+
+def test_update_raises_when_invalid_id(
+    event_repo_mock,
+):
+    event = event_service.get("a.b.c.d")
+    assert event is not None  # needed to placate pyright
+    event.import_id = "invalid"
+
+    with pytest.raises(ValidationError) as e:
+        event_service.update(event.import_id, _to_write_dto(event))
+    expected_msg = f"The import id {event.import_id} is invalid!"
+    assert e.value.message == expected_msg
+    assert event_repo_mock.update.call_count == 0
 
 
 # --- COUNT


### PR DESCRIPTION
# Description

Please include:

- Added update service and repo for family events
- Unit and integration tests for the above

[Link to Linear ticket](https://linear.app/climate-policy-radar/issue/PDCT-311/endpoint-for-updating-events)

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit and integration tests added.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
