### PR TITLE
PDCT-445 Implemented soft delete for families.

### DIFF
--- a/app/service/family.py
+++ b/app/service/family.py
@@ -154,7 +154,6 @@ def delete(import_id: str, db: Session = db_session.get_db()) -> bool:
         msg = f"Unable to delete family {import_id}"
         _LOGGER.exception(msg)
         raise RepositoryError(msg)
-    return family_repo.delete(db, import_id)
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))


### PR DESCRIPTION
# Description

- Implemented soft delete for families, which includes soft deleting all documents associated with that family.
- Updated unit and integration tests.

[Link to Linear ticket](https://linear.app/climate-policy-radar/issue/PDCT-445/implement-soft-delete-on-family)

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit and integration tests added.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
