### PR TITLE
PDCT-495 Add collections to family on family  create.

### DIFF
--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -320,9 +320,9 @@ def create(db: Session, family: FamilyCreateDTO, geo_id: int, org_id: int) -> st
             name=generate_slug(db, family.title),
         )
     )
+    db.flush()
 
     # Add the metadata
-    db.flush()
     tax = (
         db.query(MetadataOrganisation)
         .filter(MetadataOrganisation.organisation_id == org_id)
@@ -335,10 +335,10 @@ def create(db: Session, family: FamilyCreateDTO, geo_id: int, org_id: int) -> st
             value=family.metadata,
         )
     )
+    db.flush()
 
     # Add any collections.
     for col in set(family.collections):
-        db.flush()
         new_collection = CollectionFamily(
             family_import_id=new_family.import_id,
             collection_import_id=col,

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -172,9 +172,7 @@ def search(db: Session, search_term: str) -> list[FamilyReadDTO]:
     return [_family_to_dto(db, f) for f in found]
 
 
-def update(
-    db: Session, import_id: str, family: FamilyWriteDTO, geo_id: int, org_id: int
-) -> bool:
+def update(db: Session, import_id: str, family: FamilyWriteDTO, geo_id: int) -> bool:
     """
     Updates a single entry with the new values passed.
 
@@ -182,7 +180,6 @@ def update(
     :param str import_id: The family import id to change.
     :param FamilyDTO family: The new values
     :param int geo_id: a validated geography id
-    :param int org_id: a validated organisation id
     :return bool: True if new values were set otherwise false.
     """
     new_values = family.model_dump()
@@ -338,6 +335,15 @@ def create(db: Session, family: FamilyCreateDTO, geo_id: int, org_id: int) -> st
             value=family.metadata,
         )
     )
+
+    # Add any collections.
+    for col in set(family.collections):
+        db.flush()
+        new_collection = CollectionFamily(
+            family_import_id=new_family.import_id,
+            collection_import_id=col,
+        )
+        db.add(new_collection)
     return cast(str, new_family.import_id)
 
 

--- a/app/service/collection.py
+++ b/app/service/collection.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional
 
 from pydantic import ConfigDict, validate_call
-from app.errors import RepositoryError, ValidationError
+from app.errors import RepositoryError
 from app.model.collection import (
     CollectionCreateDTO,
     CollectionReadDTO,

--- a/app/service/collection.py
+++ b/app/service/collection.py
@@ -175,7 +175,7 @@ def count() -> Optional[int]:
 def get_org_from_id(db: Session, collection_import_id: str) -> Optional[int]:
     org = collection_repo.get_org_from_collection_id(db, collection_import_id)
     if org is None:
-        _LOGGER.warning(
+        _LOGGER.error(
             "The collection import id %s does not have an associated organisation",
             collection_import_id,
         )

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -165,7 +165,6 @@ def create(
     category.validate(family.category)
 
     # Validate metadata.
-    _LOGGER.warning(org_id)
     metadata.validate(db, org_id, family.metadata)
 
     # Validate collection ids.

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -115,9 +115,9 @@ def update(
     user_org_id = app_user.get_organisation(db, user_email)
     org_id = organisation.get_id(db, family.organisation)
     if org_id != user_org_id:
-        raise ValidationError(
-            f"Current user does not belong to the organisation that owns family {import_id}"
-        )
+        msg = "Current user does not belong to the organisation that owns family "
+        msg += import_id
+        raise ValidationError(msg)
 
     # Validate metadata.
     metadata.validate(db, org_id, family_dto.metadata)
@@ -132,11 +132,11 @@ def update(
         collection.get_org_from_id(db, c) != org_id for c in all_cols_to_modify
     ]
     if len(collections_not_in_user_org) > 0 and any(collections_not_in_user_org):
-        msg = "Some collections do not belong to the same organisation as the current user"
+        msg = "Organisation mismatch between some collections and the current user"
         _LOGGER.error(msg)
         raise ValidationError(msg)
 
-    if family_repo.update(db, import_id, family_dto, geo_id, org_id):
+    if family_repo.update(db, import_id, family_dto, geo_id):
         db.commit()
         return get(import_id)
 
@@ -164,8 +164,23 @@ def create(
     # Validate category
     category.validate(family.category)
 
-    # Validate organisation
+    # Validate metadata.
+    _LOGGER.warning(org_id)
     metadata.validate(db, org_id, family.metadata)
+
+    # Validate collection ids.
+    collections = set(family.collections)
+    id.validate_multiple_ids(collections)
+
+    # Validate that the collections we want to update are from the same organisation as
+    # the current user.
+    collections_not_in_user_org = [
+        collection.get_org_from_id(db, c) != org_id for c in collections
+    ]
+    if len(collections_not_in_user_org) > 0 and any(collections_not_in_user_org):
+        msg = "Organisation mismatch between some collections and the current user"
+        _LOGGER.error(msg)
+        raise ValidationError(msg)
 
     return family_repo.create(db, family, geo_id, org_id)
 

--- a/app/service/id.py
+++ b/app/service/id.py
@@ -15,7 +15,7 @@ def validate(import_id: str) -> None:
     raise ValidationError(f"The import id {import_id} is invalid!")
 
 
-def validate_multiple_ids(import_ids: list[str]) -> None:
+def validate_multiple_ids(import_ids: set[str]) -> None:
     invalid_ids = [
         import_id
         for import_id in import_ids

--- a/integration_tests/family/test_update.py
+++ b/integration_tests/family/test_update.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from fastapi.testclient import TestClient
 from fastapi import status
 from sqlalchemy.orm import Session
@@ -43,7 +44,7 @@ def test_update_family(client: TestClient, test_db: Session, user_header_token):
     assert len(db_slug) == 2
     assert str(db_slug[-1].name).startswith("updated-title")
 
-    db_collection: CollectionFamily = (
+    db_collection: Optional[list[CollectionFamily]] = (
         test_db.query(CollectionFamily)
         .filter(CollectionFamily.collection_import_id == "C.0.0.3")
         .all()
@@ -134,7 +135,7 @@ def test_update_family_append_collections(
     assert len(db_slug) == 2
     assert str(db_slug[-1].name).startswith("updated-title")
 
-    db_collections: CollectionFamily = (
+    db_collections: Optional[list[CollectionFamily]] = (
         test_db.query(CollectionFamily)
         .filter(CollectionFamily.family_import_id == "A.0.0.1")
         .all()
@@ -194,10 +195,10 @@ def test_update_family_when_collection_org_different_to_family_org(
     data = response.json()
     assert (
         data["detail"]
-        == "Some collections do not belong to the same organisation as the current user"
+        == "Organisation mismatch between some collections and the current user"
     )
 
-    db_families: Family = (
+    db_families: Optional[list[Family]] = (
         test_db.query(Family).filter(Family.import_id == "A.0.0.1").all()
     )
     assert len(db_families) == 1

--- a/integration_tests/setup_db.py
+++ b/integration_tests/setup_db.py
@@ -243,7 +243,7 @@ def _get_org_id_from_name(test_db: Session, name: str) -> int:
     return test_db.query(Organisation.id).filter(Organisation.name == name).scalar()
 
 
-def _setup_organisation(test_db: Session) -> int:
+def _setup_organisation(test_db: Session) -> tuple[int, int]:
     # Now an organisation
     org = Organisation(
         name="CCLW",

--- a/unit_tests/mocks/repos/collection_repo.py
+++ b/unit_tests/mocks/repos/collection_repo.py
@@ -14,6 +14,7 @@ def mock_collection_repo(collection_repo, monkeypatch: MonkeyPatch, mocker):
     collection_repo.invalid_org = False
     collection_repo.missing = False
     collection_repo.throw_repository_error = False
+    collection_repo.alternative_org = False
 
     def maybe_throw():
         if collection_repo.throw_repository_error:
@@ -63,6 +64,8 @@ def mock_collection_repo(collection_repo, monkeypatch: MonkeyPatch, mocker):
             return None
         if collection_repo.invalid_org is True:
             return INCORRECT_ORG_ID
+        if collection_repo.alternative_org is True:
+            return 2
         return ORG_ID
 
     monkeypatch.setattr(collection_repo, "get", mock_get)

--- a/unit_tests/mocks/repos/family_repo.py
+++ b/unit_tests/mocks/repos/family_repo.py
@@ -28,9 +28,7 @@ def mock_family_repo(family_repo, monkeypatch: MonkeyPatch, mocker):
             return [create_family_dto("search1")]
         return []
 
-    def mock_update(
-        _, import_id: str, user_email: str, data: FamilyReadDTO, __
-    ) -> bool:
+    def mock_update(_, import_id: str, user_email: str, data: FamilyReadDTO) -> bool:
         maybe_throw()
         return not family_repo.return_empty
 


### PR DESCRIPTION
# Description

Building on work in [this PR](https://github.com/climatepolicyradar/navigator-admin-backend/pull/41). 

- Add families to collections by adding collections to family on family create
- Added validation of import IDs of added/modified collections on family create
- Added validation of collection organisations against current user organisation

[Link to Linear ticket](https://linear.app/climate-policy-radar/issue/PDCT-495/add-families-to-collections-implement)

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small driveby fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
