### PR TITLE
Feature/pdct 633 add timeout exception to search api

### DIFF
--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -87,8 +87,13 @@ async def search_family(request: Request) -> list[FamilyReadDTO]:
     try:
         families = family_service.search(query_params)
     except ValidationError as e:
-        _LOGGER.error(e.message)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
+    except TimeoutError:
+        msg = "Request timed out fetching matching families. Try adjusting your query."
+        raise HTTPException(
+            status_code=status.HTTP_408_REQUEST_TIMEOUT,
+            detail=msg,
+        )
 
     if len(families) == 0:
         _LOGGER.info(f"Families not found for terms: {query_params}")

--- a/app/repository/protocols.py
+++ b/app/repository/protocols.py
@@ -1,4 +1,4 @@
-from typing import Optional, Protocol
+from typing import Optional, Protocol, Union
 from sqlalchemy.orm import Session
 
 from app.model.family import FamilyCreateDTO, FamilyReadDTO, FamilyWriteDTO
@@ -18,7 +18,9 @@ class FamilyRepo(Protocol):
         ...
 
     @staticmethod
-    def search(db: Session, query_params: dict[str, str]) -> list[FamilyReadDTO]:
+    def search(
+        db: Session, query_params: dict[str, Union[str, int]]
+    ) -> list[FamilyReadDTO]:
         """Searches the families"""
         ...
 

--- a/integration_tests/family/test_search.py
+++ b/integration_tests/family/test_search.py
@@ -1,6 +1,9 @@
-from fastapi.testclient import TestClient
+import logging
+
 from fastapi import status
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+
 from integration_tests.setup_db import setup_db
 
 
@@ -21,6 +24,25 @@ def test_search_family(client: TestClient, test_db: Session, user_header_token):
     assert ids_found.symmetric_difference(expected_ids) == set([])
 
 
+def test_search_family_with_max_results(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/families/?q=orange&max_results=1",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert type(data) is list
+
+    ids_found = set([f["import_id"] for f in data])
+    assert len(ids_found) == 1
+
+    expected_ids = set(["A.0.0.2"])
+    assert ids_found.symmetric_difference(expected_ids) == set([])
+
+
 def test_search_family_when_not_authenticated(client: TestClient, test_db: Session):
     setup_db(test_db)
     response = client.get(
@@ -30,13 +52,26 @@ def test_search_family_when_not_authenticated(client: TestClient, test_db: Sessi
 
 
 def test_search_family_when_not_found(
+    client: TestClient, test_db: Session, user_header_token, caplog
+):
+    setup_db(test_db)
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            "/api/v1/families/?q=chicken",
+            headers=user_header_token,
+        )
+    assert response.status_code == status.HTTP_200_OK
+    assert "Families not found for terms: {'q': 'chicken'}" in caplog.text
+
+
+def test_search_family_when_invalid_params(
     client: TestClient, test_db: Session, user_header_token
 ):
     setup_db(test_db)
     response = client.get(
-        "/api/v1/families/?q=chicken",
+        "/api/v1/families/?wrong=param",
         headers=user_header_token,
     )
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     data = response.json()
-    assert data["detail"] == "Families not found for terms: {'q': 'chicken'}"
+    assert data["detail"] == "Search parameters are invalid: ['wrong']"

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -97,6 +97,7 @@ def family_repo_mock(monkeypatch, mocker):
     # set some attributes for testing purposes...
     setattr(family_repo, "return_empty", False)
     setattr(family_repo, "throw_repository_error", False)
+    setattr(family_repo, "throw_timeout_error", False)
 
     yield family_repo
 

--- a/unit_tests/mocks/repos/family_repo.py
+++ b/unit_tests/mocks/repos/family_repo.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from sqlalchemy import exc
 from sqlalchemy.orm import Session
@@ -23,11 +23,13 @@ def get(db: Session, import_id: str) -> Optional[FamilyReadDTO]:
         return create_family_dto(import_id)
 
 
-def search(db: Session, query_params: dict[str, str]) -> list[FamilyReadDTO]:
+def search(
+    db: Session, query_params: dict[str, Union[str, int]]
+) -> list[FamilyReadDTO]:
     _maybe_throw()
-    if getattr(family_repo, "return_empty") is False:
-        return [create_family_dto("search1")]
-    return []
+    if getattr(family_repo, "return_empty"):
+        return []
+    return [create_family_dto("search1")]
 
 
 def update(db: Session, import_id: str, family: FamilyWriteDTO, geo_id: int) -> bool:

--- a/unit_tests/mocks/repos/family_repo.py
+++ b/unit_tests/mocks/repos/family_repo.py
@@ -13,6 +13,11 @@ def _maybe_throw():
         raise exc.SQLAlchemyError("bad repo")
 
 
+def _maybe_timeout():
+    if getattr(family_repo, "throw_timeout_error") is True:
+        raise TimeoutError
+
+
 def all(db: Session):
     return [create_family_dto("test")]
 
@@ -27,6 +32,7 @@ def search(
     db: Session, query_params: dict[str, Union[str, int]]
 ) -> list[FamilyReadDTO]:
     _maybe_throw()
+    _maybe_timeout()
     if getattr(family_repo, "return_empty"):
         return []
     return [create_family_dto("search1")]

--- a/unit_tests/mocks/services/family_service.py
+++ b/unit_tests/mocks/services/family_service.py
@@ -11,10 +11,15 @@ def mock_family_service(family_service, monkeypatch: MonkeyPatch, mocker):
     family_service.missing = False
     family_service.invalid_collections = False
     family_service.throw_repository_error = False
+    family_service.throw_timeout_error = False
 
     def maybe_throw():
         if family_service.throw_repository_error:
             raise RepositoryError("bad repo")
+
+    def maybe_timeout():
+        if family_service.throw_timeout_error:
+            raise TimeoutError
 
     def mock_get_all_families():
         return [create_family_dto("test")]
@@ -39,6 +44,7 @@ def mock_family_service(family_service, monkeypatch: MonkeyPatch, mocker):
         if q_params["q"] == "empty":
             return []
 
+        maybe_timeout()
         return [create_family_dto("search1")]
 
     def mock_update_family(

--- a/unit_tests/mocks/services/family_service.py
+++ b/unit_tests/mocks/services/family_service.py
@@ -1,7 +1,8 @@
 from typing import Optional
-from pytest import MonkeyPatch
-from app.errors import RepositoryError
 
+from pytest import MonkeyPatch
+
+from app.errors import RepositoryError, ValidationError
 from app.model.family import FamilyReadDTO, FamilyWriteDTO
 from unit_tests.helpers.family import create_family_dto
 
@@ -23,10 +24,22 @@ def mock_family_service(family_service, monkeypatch: MonkeyPatch, mocker):
             return create_family_dto(import_id)
 
     def mock_search_families(q_params: dict) -> list[FamilyReadDTO]:
+        VALID_PARAMS = [
+            "q",
+            "title",
+            "description",
+            "geography",
+            "status",
+            "max_results",
+        ]
+        invalid_params = [x for x in q_params if x not in VALID_PARAMS]
+        if any(invalid_params):
+            raise ValidationError(f"Search parameters are invalid: {invalid_params}")
+
         if q_params["q"] == "empty":
             return []
-        else:
-            return [create_family_dto("search1")]
+
+        return [create_family_dto("search1")]
 
     def mock_update_family(
         import_id: str, user_email: str, data: FamilyWriteDTO

--- a/unit_tests/routers/test_family.py
+++ b/unit_tests/routers/test_family.py
@@ -59,6 +59,15 @@ def test_search_when_invalid_params(
     assert family_service_mock.search.call_count == 1
 
 
+def test_search_when_request_timeout(
+    client: TestClient, family_service_mock, user_header_token
+):
+    family_service_mock.throw_timeout_error = True
+    response = client.get("/api/v1/families/?q=timeout", headers=user_header_token)
+    assert response.status_code == status.HTTP_408_REQUEST_TIMEOUT
+    assert family_service_mock.search.call_count == 1
+
+
 def test_search_when_not_found(
     client: TestClient, family_service_mock, user_header_token, caplog
 ):

--- a/unit_tests/service/test_family_service.py
+++ b/unit_tests/service/test_family_service.py
@@ -84,6 +84,13 @@ def test_search_invalid_params(family_repo_mock):
     assert family_repo_mock.search.call_count == 0
 
 
+def test_search_request_timeout(family_repo_mock):
+    family_repo_mock.throw_timeout_error = True
+    with pytest.raises(TimeoutError):
+        family_service.search({"q": "timeout"})
+    assert family_repo_mock.search.call_count == 1
+
+
 def test_search_missing(family_repo_mock):
     family_repo_mock.return_empty = True
     result = family_service.search({"q": "empty"})

--- a/unit_tests/service/test_family_service.py
+++ b/unit_tests/service/test_family_service.py
@@ -4,12 +4,13 @@ Tests the family service.
 Uses a family repo mock and ensures that the repo is called.
 """
 from typing import Optional
-import pytest
-from app.errors import ValidationError, RepositoryError
-from app.model.family import FamilyCreateDTO, FamilyReadDTO, FamilyWriteDTO
-import app.service.family as family_service
-from unit_tests.helpers.family import create_family_dto
 
+import pytest
+
+import app.service.family as family_service
+from app.errors import RepositoryError, ValidationError
+from app.model.family import FamilyCreateDTO, FamilyReadDTO, FamilyWriteDTO
+from unit_tests.helpers.family import create_family_dto
 
 USER_EMAIL = "test@cpr.org"
 ORG_ID = 1
@@ -73,6 +74,14 @@ def test_search(family_repo_mock):
     assert result is not None
     assert len(result) == 1
     assert family_repo_mock.search.call_count == 1
+
+
+def test_search_invalid_params(family_repo_mock):
+    with pytest.raises(ValidationError) as e:
+        family_service.search({"wrong": "yes"})
+    expected_msg = "Search parameters are invalid: ['wrong']"
+    assert e.value.message == expected_msg
+    assert family_repo_mock.search.call_count == 0
 
 
 def test_search_missing(family_repo_mock):


### PR DESCRIPTION
# Description

Please include:

- Added timeout error handling
- Added max_results query param and set default to 500
- Updated family search to return 200 with empty response instead of 404 when no matching families found
- Linear ticket [PDCT-633](https://linear.app/climate-policy-radar/issue/PDCT-633/add-timeout-exception-to-search-api)

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit & integration tests added.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
