### PR TITLE
Make document_role optional - as per db schema

### DIFF
--- a/app/model/document.py
+++ b/app/model/document.py
@@ -16,7 +16,7 @@ class DocumentReadDTO(BaseModel):
     family_import_id: str
     variant_name: Optional[str]
     status: DocumentStatus
-    role: str
+    role: Optional[str]
     type: Optional[str]
     slug: str
     created: datetime

--- a/app/model/document.py
+++ b/app/model/document.py
@@ -37,7 +37,7 @@ class DocumentWriteDTO(BaseModel):
 
     # From FamilyDocument
     variant_name: Optional[str]
-    role: str
+    role: Optional[str]
     type: Optional[str]
     title: str
     source_url: Optional[str]


### PR DESCRIPTION
# Description

This fix is the result of seeing this error:

```
 File \"/usr/src/app/api/api_v1/routers/document.py\", line 81, 
    in search_document
    documents = document_service.search(q)
  
File \"/usr/local/lib/python3.9/site-packages/pydantic/_internal/_validate_call.py\", line 100, 
    in __call__
    res = self.__pydantic_validator__.validate_python(pydantic_core.ArgsKwargs(args, kwargs))

File \"/usr/src/app/service/document.py\", line 66, 
    in search
    return document_repo.search(db, search_term)

File \"/usr/src/app/repository/document.py\", line 175, 
   in search
    return [DocumentReadDTO(**dict(r)) for r in result]

File \"/usr/src/app/repository/document.py\", line 175, 
    in <listcomp>
    return [DocumentReadDTO(**dict(r)) for r in result]

File \"/usr/local/lib/python3.9/site-packages/pydantic/main.py\", line 164, 
    in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
    pydantic_core._pydantic_core.ValidationError: 1 validation error for DocumentReadDTO
   role
   Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.4/v/string_type\n",
```


## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
