### PR TITLE
Feature/pdct 654 return empty 200 on all search entities when no results foun

### DIFF
--- a/app/api/api_v1/query_params.py
+++ b/app/api/api_v1/query_params.py
@@ -10,7 +10,7 @@ def get_query_params_as_dict(query_params) -> dict[str, Union[str, int]]:
 
 def set_default_query_params(
     query_params,
-    default_search_params,
+    default_search_fields,
     default_query_term: str = "",
     default_max_results: int = 500,
 ) -> dict[str, Union[str, int]]:
@@ -22,7 +22,7 @@ def set_default_query_params(
     if "max_results" not in query_fields:
         query_params["max_results"] = default_max_results
 
-    query_params = remove_duplicate_query_params(query_params, default_search_params)
+    query_params = remove_duplicate_query_params(query_params, default_search_fields)
     return query_params
 
 

--- a/app/api/api_v1/query_params.py
+++ b/app/api/api_v1/query_params.py
@@ -10,7 +10,6 @@ def get_query_params_as_dict(query_params) -> dict[str, Union[str, int]]:
 
 def set_default_query_params(
     query_params,
-    default_search_fields,
     default_query_term: str = "",
     default_max_results: int = 500,
 ) -> dict[str, Union[str, int]]:
@@ -22,7 +21,6 @@ def set_default_query_params(
     if "max_results" not in query_fields:
         query_params["max_results"] = default_max_results
 
-    query_params = remove_duplicate_query_params(query_params, default_search_fields)
     return query_params
 
 
@@ -46,13 +44,3 @@ def validate_query_params(
                 detail="Maximum results must be an integer value",
             )
     return True
-
-
-def remove_duplicate_query_params(
-    query_params, params_to_remove: list[str]
-) -> dict[str, Union[str, int]]:
-    for param in params_to_remove:
-        if all(k in query_params.keys() for k in ("q", param)):
-            query_params.pop(param)
-
-    return query_params

--- a/app/api/api_v1/query_params.py
+++ b/app/api/api_v1/query_params.py
@@ -9,7 +9,10 @@ def get_query_params_as_dict(query_params) -> dict[str, Union[str, int]]:
 
 
 def set_default_query_params(
-    query_params, default_query_term: str = "", default_max_results: int = 500
+    query_params,
+    default_search_params,
+    default_query_term: str = "",
+    default_max_results: int = 500,
 ) -> dict[str, Union[str, int]]:
     query_fields = query_params.keys()
 
@@ -18,6 +21,8 @@ def set_default_query_params(
 
     if "max_results" not in query_fields:
         query_params["max_results"] = default_max_results
+
+    query_params = remove_duplicate_query_params(query_params, default_search_params)
     return query_params
 
 
@@ -43,7 +48,7 @@ def validate_query_params(
     return True
 
 
-def remove_query_params(
+def remove_duplicate_query_params(
     query_params, params_to_remove: list[str]
 ) -> dict[str, Union[str, int]]:
     for param in params_to_remove:

--- a/app/api/api_v1/query_params.py
+++ b/app/api/api_v1/query_params.py
@@ -1,0 +1,53 @@
+from typing import Union, cast
+
+from fastapi import HTTPException, status
+
+
+def get_query_params_as_dict(query_params) -> dict[str, Union[str, int]]:
+    print(query_params)
+    return {k: query_params[k] for k in query_params.keys()}
+
+
+def set_default_query_params(
+    query_params, default_query_term: str = "", default_max_results: int = 500
+) -> dict[str, Union[str, int]]:
+    query_fields = query_params.keys()
+
+    if len(query_fields) < 1:
+        return {"q": default_query_term, "max_results": default_max_results}
+
+    if "max_results" not in query_fields:
+        query_params["max_results"] = default_max_results
+    return query_params
+
+
+def validate_query_params(
+    query_params, valid_params: list[str] = ["q", "max_results"]
+) -> bool:
+    query_fields = query_params.keys()
+    invalid_params = [x for x in query_fields if x not in valid_params]
+    if any(invalid_params):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Search parameters are invalid: {invalid_params}",
+        )
+
+    if not isinstance(query_params["max_results"], int):
+        try:
+            query_params.update({"max_results": cast(int, query_params["max_results"])})
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Maximum results must be an integer value",
+            )
+    return True
+
+
+def remove_query_params(
+    query_params, params_to_remove: list[str]
+) -> dict[str, Union[str, int]]:
+    for param in params_to_remove:
+        if all(k in query_params.keys() for k in ("q", param)):
+            query_params.pop(param)
+
+    return query_params

--- a/app/api/api_v1/routers/collection.py
+++ b/app/api/api_v1/routers/collection.py
@@ -92,8 +92,7 @@ async def search_collection(request: Request) -> list[CollectionReadDTO]:
 
     query_params = get_query_params_as_dict(request.query_params)
 
-    DEFAULT_SEARCH_FIELDS = ["title", "description"]
-    query_params = set_default_query_params(query_params, DEFAULT_SEARCH_FIELDS)
+    query_params = set_default_query_params(query_params)
 
     VALID_PARAMS = ["q", "max_results"]
     validate_query_params(query_params, VALID_PARAMS)

--- a/app/api/api_v1/routers/collection.py
+++ b/app/api/api_v1/routers/collection.py
@@ -77,11 +77,17 @@ async def get_all_collections() -> list[CollectionReadDTO]:
 )
 async def search_collection(request: Request) -> list[CollectionReadDTO]:
     """
-    Searches for collections matching the "q" URL parameter.
+    Searches for collections matching URL parameters ("q" by default).
 
-    :param str q: The string to match, defaults to ""
-    :raises HTTPException: If nothing found a 404 is returned.
-    :return list[CollectionDTO]: A list of matching collections.
+    :param Request request: The fields to match against and the values
+        to search for. Defaults to searching for "" in collection titles
+        and summaries.
+    :raises HTTPException: If invalid fields passed a 400 is returned.
+    :raises HTTPException: If a DB error occurs a 503 is returned.
+    :raises HTTPException: If the search request times out a 408 is
+        returned.
+    :return list[CollectionReadDTO]: A list of matching collections
+        (which can be empty).
     """
 
     query_params = get_query_params_as_dict(request.query_params)

--- a/app/api/api_v1/routers/collection.py
+++ b/app/api/api_v1/routers/collection.py
@@ -1,14 +1,15 @@
 """Endpoints for managing the Collection entity."""
 import logging
-from fastapi import APIRouter, HTTPException, Request, status
-from app.errors import RepositoryError, ValidationError
 
+from fastapi import APIRouter, HTTPException, Request, status
+
+import app.service.collection as collection_service
+from app.errors import RepositoryError, ValidationError
 from app.model.collection import (
+    CollectionCreateDTO,
     CollectionReadDTO,
     CollectionWriteDTO,
-    CollectionCreateDTO,
 )
-import app.service.collection as collection_service
 
 collections_router = r = APIRouter()
 
@@ -85,10 +86,7 @@ async def search_collection(q: str = "") -> list[CollectionReadDTO]:
         )
 
     if len(collections) == 0:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Collections not found for term: {q}",
-        )
+        _LOGGER.info(f"Collections not found for terms: {q}")
 
     return collections
 

--- a/app/api/api_v1/routers/document.py
+++ b/app/api/api_v1/routers/document.py
@@ -1,14 +1,15 @@
 """Endpoints for managing the Document entity."""
 import logging
+
 from fastapi import APIRouter, HTTPException, status
+
+import app.service.document as document_service
 from app.errors import RepositoryError, ValidationError
 from app.model.document import (
     DocumentCreateDTO,
     DocumentReadDTO,
     DocumentWriteDTO,
 )
-
-import app.service.document as document_service
 
 document_router = r = APIRouter()
 
@@ -85,10 +86,7 @@ async def search_document(q: str = "") -> list[DocumentReadDTO]:
         )
 
     if len(documents) == 0:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Documents not found for term: {q}",
-        )
+        _LOGGER.info(f"Documents not found for terms: {q}")
 
     return documents
 

--- a/app/api/api_v1/routers/document.py
+++ b/app/api/api_v1/routers/document.py
@@ -77,11 +77,16 @@ async def get_all_documents() -> list[DocumentReadDTO]:
 )
 async def search_document(request: Request) -> list[DocumentReadDTO]:
     """
-    Searches for documents matching the "q" URL parameter.
+    Searches for documents matching URL parameters ("q" by default).
 
-    :param str q: The string to match, defaults to ""
-    :raises HTTPException: If nothing found a 404 is returned.
-    :return list[DocumentDTO]: A list of matching documents.
+    :param Request request: The fields to match against and the values
+        to search for. Defaults to searching for "" in document titles.
+    :raises HTTPException: If invalid fields passed a 400 is returned.
+    :raises HTTPException: If a DB error occurs a 503 is returned.
+    :raises HTTPException: If the search request times out a 408 is
+        returned.
+    :return list[DocumentReadDTO]: A list of matching documents (which
+        can be empty).
     """
     query_params = get_query_params_as_dict(request.query_params)
 

--- a/app/api/api_v1/routers/document.py
+++ b/app/api/api_v1/routers/document.py
@@ -90,8 +90,7 @@ async def search_document(request: Request) -> list[DocumentReadDTO]:
     """
     query_params = get_query_params_as_dict(request.query_params)
 
-    DEFAULT_SEARCH_FIELDS = ["title"]
-    query_params = set_default_query_params(query_params, DEFAULT_SEARCH_FIELDS)
+    query_params = set_default_query_params(query_params)
 
     VALID_PARAMS = ["q", "max_results"]
     validate_query_params(query_params, VALID_PARAMS)

--- a/app/api/api_v1/routers/event.py
+++ b/app/api/api_v1/routers/event.py
@@ -58,8 +58,7 @@ async def search_event(request: Request) -> list[EventReadDTO]:
     """
     query_params = get_query_params_as_dict(request.query_params)
 
-    DEFAULT_SEARCH_FIELDS = ["title", "event_type_value"]
-    query_params = set_default_query_params(query_params, DEFAULT_SEARCH_FIELDS)
+    query_params = set_default_query_params(query_params)
 
     VALID_PARAMS = ["q", "max_results"]
     validate_query_params(query_params, VALID_PARAMS)

--- a/app/api/api_v1/routers/event.py
+++ b/app/api/api_v1/routers/event.py
@@ -44,11 +44,17 @@ async def get_all_events() -> list[EventReadDTO]:
 )
 async def search_event(request: Request) -> list[EventReadDTO]:
     """
-    Searches for family events matching the "q" URL parameter.
+    Searches for family events matching URL parameters ("q" by default).
 
-    :param str q: The string to match, defaults to ""
-    :raises HTTPException: If nothing found a 404 is returned.
-    :return list[EventDTO]: A list of matching events.
+    :param Request request: The fields to match against and the values
+        to search for. Defaults to searching for "" in event titles and
+        type names.
+    :raises HTTPException: If invalid fields passed a 400 is returned.
+    :raises HTTPException: If a DB error occurs a 503 is returned.
+    :raises HTTPException: If the search request times out a 408 is
+        returned.
+    :return list[EventReadDTO]: A list of matching events (which can be
+        empty).
     """
     query_params = get_query_params_as_dict(request.query_params)
 

--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -91,7 +91,7 @@ async def search_family(request: Request) -> list[FamilyReadDTO]:
 
     query_params = set_default_query_params(query_params)
 
-    VALID_PARAMS = ["q", "title", "description", "geography", "status", "max_results"]
+    VALID_PARAMS = ["q", "title", "summary", "geography", "status", "max_results"]
     validate_query_params(query_params, VALID_PARAMS)
 
     try:

--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -89,8 +89,7 @@ async def search_family(request: Request) -> list[FamilyReadDTO]:
     """
     query_params = get_query_params_as_dict(request.query_params)
 
-    DEFAULT_SEARCH_FIELDS = ["title", "description"]
-    query_params = set_default_query_params(query_params, DEFAULT_SEARCH_FIELDS)
+    query_params = set_default_query_params(query_params)
 
     VALID_PARAMS = ["q", "title", "description", "geography", "status", "max_results"]
     validate_query_params(query_params, VALID_PARAMS)

--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -81,8 +81,11 @@ async def search_family(request: Request) -> list[FamilyReadDTO]:
         to search for. Defaults to searching for "" in family titles and
         summaries.
     :raises HTTPException: If invalid fields passed a 400 is returned.
-    :raises HTTPException: If nothing found a 404 is returned.
-    :return list[FamilyDTO]: A list of matching families.
+    :raises HTTPException: If a DB error occurs a 503 is returned.
+    :raises HTTPException: If the search request times out a 408 is
+        returned.
+    :return list[FamilyDTO]: A list of matching families (which can be
+        empty).
     """
     query_params = get_query_params_as_dict(request.query_params)
 

--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -86,8 +86,8 @@ async def search_family(request: Request) -> list[FamilyReadDTO]:
     """
     query_params = get_query_params_as_dict(request.query_params)
 
-    DEFAULT_SEARCH_PARAMS = ["title", "description"]
-    query_params = set_default_query_params(query_params, DEFAULT_SEARCH_PARAMS)
+    DEFAULT_SEARCH_FIELDS = ["title", "description"]
+    query_params = set_default_query_params(query_params, DEFAULT_SEARCH_FIELDS)
 
     VALID_PARAMS = ["q", "title", "description", "geography", "status", "max_results"]
     validate_query_params(query_params, VALID_PARAMS)

--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -7,11 +7,16 @@ layer would just pass through directly to the repo. So the approach
 implemented directly accesses the "repository" layer.
 """
 import logging
-from typing import Union, cast
 
 from fastapi import APIRouter, HTTPException, Request, status
 
 import app.service.family as family_service
+from app.api.api_v1.query_params import (
+    get_query_params_as_dict,
+    remove_query_params,
+    set_default_query_params,
+    validate_query_params,
+)
 from app.errors import RepositoryError, ValidationError
 from app.model.family import FamilyCreateDTO, FamilyReadDTO, FamilyWriteDTO
 
@@ -80,43 +85,15 @@ async def search_family(request: Request) -> list[FamilyReadDTO]:
     :raises HTTPException: If nothing found a 404 is returned.
     :return list[FamilyDTO]: A list of matching families.
     """
-    query_params: dict[str, Union[str, int]] = {
-        k: request.query_params[k] for k in request.query_params.keys()
-    }
+    query_params = get_query_params_as_dict(request.query_params)
 
-    query_fields = query_params.keys()
-    if len(query_fields) < 1:
-        query_params = {"q": ""}
+    query_params = set_default_query_params(query_params)
 
     VALID_PARAMS = ["q", "title", "description", "geography", "status", "max_results"]
-    invalid_params = [x for x in query_fields if x not in VALID_PARAMS]
-    if any(invalid_params):
-        msg = f"Search parameters are invalid: {invalid_params}"
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=msg,
-        )
+    validate_query_params(query_params, VALID_PARAMS)
 
-    if "q" in query_fields:
-        if "title" in query_fields:
-            query_params.pop("title")
-        if "description" in query_fields:
-            query_params.pop("description")
-
-    DEFAULT_MAX_RESULTS = 500
-    if "max_results" not in query_fields:
-        query_params["max_results"] = DEFAULT_MAX_RESULTS
-    else:
-        if not isinstance(query_params["max_results"], int):
-            try:
-                query_params.update(
-                    {"max_results": cast(int, query_params["max_results"])}
-                )
-            except Exception:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Maximum results must be an integer value",
-                )
+    PARAMS_TO_REMOVE = ["title", "description"]
+    query_params = remove_query_params(query_params, PARAMS_TO_REMOVE)
 
     try:
         families = family_service.search(query_params)

--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -13,7 +13,6 @@ from fastapi import APIRouter, HTTPException, Request, status
 import app.service.family as family_service
 from app.api.api_v1.query_params import (
     get_query_params_as_dict,
-    remove_query_params,
     set_default_query_params,
     validate_query_params,
 )
@@ -87,13 +86,11 @@ async def search_family(request: Request) -> list[FamilyReadDTO]:
     """
     query_params = get_query_params_as_dict(request.query_params)
 
-    query_params = set_default_query_params(query_params)
+    DEFAULT_SEARCH_PARAMS = ["title", "description"]
+    query_params = set_default_query_params(query_params, DEFAULT_SEARCH_PARAMS)
 
     VALID_PARAMS = ["q", "title", "description", "geography", "status", "max_results"]
     validate_query_params(query_params, VALID_PARAMS)
-
-    PARAMS_TO_REMOVE = ["title", "description"]
-    query_params = remove_query_params(query_params, PARAMS_TO_REMOVE)
 
     try:
         families = family_service.search(query_params)

--- a/app/repository/collection.py
+++ b/app/repository/collection.py
@@ -122,11 +122,15 @@ def search(
     db: Session, query_params: dict[str, Union[str, int]]
 ) -> list[CollectionReadDTO]:
     """
-    Gets a list of collections from the repository searching title and description.
+    Gets a list of collections from the repo searching given fields.
 
     :param db Session: the database connection
-    :param str search_term: Any search term to filter on title or summary
-    :return Optional[list[CollectionResponse]]: A list of matches
+    :param dict query_params: Any search terms to filter on specified
+        fields (title & summary by default if 'q' specified).
+    :raises HTTPException: If a DB error occurs a 503 is returned.
+    :raises HTTPException: If the search request times out a 408 is
+        returned.
+    :return list[CollectionResponse]: A list of matching collections.
     """
     search = []
     if "q" in query_params.keys():

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -166,8 +166,12 @@ def search(
     Gets a list of documents from the repository searching the title.
 
     :param db Session: the database connection
-    :param str search_term: Any search term to filter on title or summary
-    :return Optional[list[DocumentResponse]]: A list of matches
+    :param dict query_params: Any search terms to filter on specified
+        fields (title by default if 'q' specified).
+    :raises HTTPException: If a DB error occurs a 503 is returned.
+    :raises HTTPException: If the search request times out a 408 is
+        returned.
+    :return list[DocumentResponse]: A list of matching documents.
     """
     search = []
     if "q" in query_params.keys():

--- a/app/repository/event.py
+++ b/app/repository/event.py
@@ -117,10 +117,12 @@ def search(db: Session, query_params: dict[str, Union[str, int]]) -> list[EventR
     Get family events matching a search term on the event title or type.
 
     :param db Session: The database connection.
-    :param str search_term: Any search term to filter on the event title
-        or event type name.
-    :return Optional[list[EventReadDTO]]: A list of matching family
-        events or none.
+    :param dict query_params: Any search terms to filter on specified
+        fields (title & event type name by default if 'q' specified).
+    :raises HTTPException: If a DB error occurs a 503 is returned.
+    :raises HTTPException: If the search request times out a 408 is
+        returned.
+    :return list[EventReadDTO]: A list of matching family events.
     """
     search = []
     if "q" in query_params.keys():

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -164,9 +164,13 @@ def search(
     Gets a list of families from the repository searching given fields.
 
     :param db Session: the database connection
-    :param dict[str, str] query_params: Any search terms to filter on
-        specified fields (title & summary by default if 'q' specified).
-    :return list[FamilyResponse]: A list of matches
+    :param dict query_params: Any search terms to filter on specified
+        fields (title & summary by default if 'q' specified).
+    :raises HTTPException: If a DB error occurs a 503 is returned.
+    :raises HTTPException: If the search request times out a 408 is
+        returned.
+    :return list[FamilyReadDTO]: A list of families matching the search
+        terms.
     """
     search = []
     if "q" in query_params.keys():

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -179,14 +179,14 @@ def search(
     if "q" in query_params.keys():
         term = f"%{escape_like(query_params['q'])}%"
         search.append(or_(Family.title.ilike(term), Family.description.ilike(term)))
+    else:
+        if "title" in query_params.keys():
+            term = f"%{escape_like(query_params['title'])}%"
+            search.append(Family.title.ilike(term))
 
-    if "title" in query_params.keys():
-        term = f"%{escape_like(query_params['title'])}%"
-        search.append(Family.title.ilike(term))
-
-    if "description" in query_params.keys():
-        term = f"%{escape_like(query_params['description'])}%"
-        search.append(Family.description.ilike(term))
+        if "description" in query_params.keys():
+            term = f"%{escape_like(query_params['description'])}%"
+            search.append(Family.description.ilike(term))
 
     if "geography" in query_params.keys():
         term = cast(str, query_params["geography"])

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -184,8 +184,8 @@ def search(
             term = f"%{escape_like(query_params['title'])}%"
             search.append(Family.title.ilike(term))
 
-        if "description" in query_params.keys():
-            term = f"%{escape_like(query_params['description'])}%"
+        if "summary" in query_params.keys():
+            term = f"%{escape_like(query_params['summary'])}%"
             search.append(Family.description.ilike(term))
 
     if "geography" in query_params.keys():

--- a/app/service/collection.py
+++ b/app/service/collection.py
@@ -61,10 +61,16 @@ def all() -> list[CollectionReadDTO]:
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def search(query_params: dict[str, Union[str, int]]) -> list[CollectionReadDTO]:
     """
-    Searches the title and descriptions of all the collections for the search term.
+    Searches for the search term against collections on specified fields.
 
-    :param str search_term: Search pattern to match.
-    :return list[CollectionDTO]: The list of collections matching the search term.
+    Where 'q' is used instead of an explicit field name, the titles and
+    descriptions of all the collections are searched for the given term
+    only.
+
+    :param dict query_params: Search patterns to match against specified
+        fields, given as key value pairs in a dictionary.
+    :return list[CollectionReadDTO]: The list of collections matching
+        the given search terms.
     """
     with db_session.get_db() as db:
         return collection_repo.search(db, query_params)

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from pydantic import ConfigDict, validate_call
 from app.clients.aws.client import get_s3_client
@@ -55,7 +55,7 @@ def all() -> list[DocumentReadDTO]:
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def search(search_term: str) -> list[DocumentReadDTO]:
+def search(query_params: dict[str, Union[str, int]]) -> list[DocumentReadDTO]:
     """
     Searches the title and descriptions of all the documents for the search term.
 
@@ -63,7 +63,7 @@ def search(search_term: str) -> list[DocumentReadDTO]:
     :return list[documentDTO]: The list of documents matching the search term.
     """
     with db_session.get_db() as db:
-        return document_repo.search(db, search_term)
+        return document_repo.search(db, query_params)
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -2,17 +2,17 @@ import logging
 from typing import Optional, Tuple, Union
 
 from pydantic import ConfigDict, validate_call
-from app.clients.aws.client import get_s3_client
-from app.errors import RepositoryError, ValidationError
-from app.model.document import DocumentCreateDTO, DocumentReadDTO, DocumentWriteDTO
-import app.repository.document as document_repo
-import app.repository.document_file as file_repo
-import app.clients.db.session as db_session
-import app.service.family as family_service
-from app.service import id
 from sqlalchemy import exc
 from sqlalchemy.orm import Session
 
+import app.clients.db.session as db_session
+import app.repository.document as document_repo
+import app.repository.document_file as file_repo
+import app.service.family as family_service
+from app.clients.aws.client import get_s3_client
+from app.errors import RepositoryError, ValidationError
+from app.model.document import DocumentCreateDTO, DocumentReadDTO, DocumentWriteDTO
+from app.service import id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,10 +57,15 @@ def all() -> list[DocumentReadDTO]:
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def search(query_params: dict[str, Union[str, int]]) -> list[DocumentReadDTO]:
     """
-    Searches the title and descriptions of all the documents for the search term.
+    Searches for the search term against documents on specified fields.
 
-    :param str search_term: Search pattern to match.
-    :return list[documentDTO]: The list of documents matching the search term.
+    Where 'q' is used instead of an explicit field name, only the titles
+    of all the documents are searched for the given term.
+
+    :param dict query_params: Search patterns to match against specified
+        fields, given as key value pairs in a dictionary.
+    :return list[DocumentReadDTO]: The list of documents matching the
+        given search terms.
     """
     with db_session.get_db() as db:
         return document_repo.search(db, query_params)

--- a/app/service/event.py
+++ b/app/service/event.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import ConfigDict, validate_call
 from sqlalchemy import exc
@@ -11,7 +11,6 @@ import app.service.family as family_service
 from app.errors import RepositoryError, ValidationError
 from app.model.event import EventCreateDTO, EventReadDTO, EventWriteDTO
 from app.service import id
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,7 +46,7 @@ def all() -> list[EventReadDTO]:
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def search(search_term: str) -> Optional[list[EventReadDTO]]:
+def search(query_params: dict[str, Union[str, int]]) -> list[EventReadDTO]:
     """
     Search for all family events that match a search term.
 
@@ -59,7 +58,7 @@ def search(search_term: str) -> Optional[list[EventReadDTO]]:
         the search term or none.
     """
     with db_session.get_db() as db:
-        return event_repo.search(db, search_term)
+        return event_repo.search(db, query_params)
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/app/service/event.py
+++ b/app/service/event.py
@@ -48,14 +48,16 @@ def all() -> list[EventReadDTO]:
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def search(query_params: dict[str, Union[str, int]]) -> list[EventReadDTO]:
     """
-    Search for all family events that match a search term.
+    Searches for the search term against events on specified fields.
 
-    Specifically searches the event title and event type name for the
-    search term.
+    Where 'q' is used instead of an explicit field name, the titles and
+    event type names of all the events are searched for the given term
+    only.
 
-    :param str search_term: Search pattern to match.
-    :return Optional[list[EventReadDTO]] The list of events that match
-        the search term or none.
+    :param dict query_params: Search patterns to match against specified
+        fields, given as key value pairs in a dictionary.
+    :return list[EventReadDTO]: The list of events matching the given
+        search terms.
     """
     with db_session.get_db() as db:
         return event_repo.search(db, query_params)

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -66,10 +66,10 @@ def search(query_params: dict[str, Union[str, int]]) -> list[FamilyReadDTO]:
     descriptions of all the Families are searched for the given term
     only.
 
-    :param str query_params: Search patterns to match against specified
-        fields.
-    :return list[FamilyDTO]: The list of families matching the search
-        term.
+    :param dict query_params: Search patterns to match against specified
+        fields, given as key value pairs in a dictionary.
+    :return list[FamilyDTO]: The list of families matching the given
+        search terms.
     """
     with db_session.get_db() as db:
         return family_repo.search(db, query_params)

--- a/integration_tests/document/test_search.py
+++ b/integration_tests/document/test_search.py
@@ -1,13 +1,73 @@
-from fastapi.testclient import TestClient
+import logging
+
 from fastapi import status
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+
 from integration_tests.setup_db import setup_db
 
 
 def test_search_document(client: TestClient, test_db: Session, user_header_token):
     setup_db(test_db)
     response = client.get(
-        "/api/v1/documents/?q=big",
+        "/api/v1/documents/?q=title",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert type(data) is list
+
+    ids_found = set([f["import_id"] for f in data])
+    assert len(ids_found) == 2
+
+    expected_ids = set(["D.0.0.1", "D.0.0.2"])
+    assert ids_found.symmetric_difference(expected_ids) == set([])
+
+
+def test_search_document_when_not_authorised(client: TestClient, test_db: Session):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/documents/?q=orange",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_search_document_when_nothing_found(
+    client: TestClient, test_db: Session, user_header_token, caplog
+):
+    setup_db(test_db)
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            "/api/v1/documents/?q=chicken",
+            headers=user_header_token,
+        )
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        "Documents not found for terms: {'q': 'chicken', 'max_results': 500}"
+        in caplog.text
+    )
+
+
+def test_search_document_when_db_error(
+    client: TestClient, test_db: Session, bad_document_repo, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/documents/?q=chicken",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["detail"] == "Bad Repo"
+    assert bad_document_repo.search.call_count == 1
+
+
+def test_search_document_with_max_results(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/documents/?q=title&max_results=1",
         headers=user_header_token,
     )
     assert response.status_code == status.HTTP_200_OK
@@ -21,34 +81,14 @@ def test_search_document(client: TestClient, test_db: Session, user_header_token
     assert ids_found.symmetric_difference(expected_ids) == set([])
 
 
-def test_search_document_when_not_authorised(client: TestClient, test_db: Session):
-    setup_db(test_db)
-    response = client.get(
-        "/api/v1/documents/?q=orange",
-    )
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-
-def test_search_document_when_nothing_found(
+def test_search_document_when_invalid_params(
     client: TestClient, test_db: Session, user_header_token
 ):
     setup_db(test_db)
     response = client.get(
-        "/api/v1/documents/?q=chicken",
+        "/api/v1/documents/?wrong=param",
         headers=user_header_token,
     )
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     data = response.json()
-    assert data["detail"] == "Documents not found for term: chicken"
-
-
-def test_search_document_when_db_error(
-    client: TestClient, test_db: Session, bad_document_repo, user_header_token
-):
-    setup_db(test_db)
-    response = client.get(
-        "/api/v1/documents/?q=chicken",
-        headers=user_header_token,
-    )
-    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-    assert bad_document_repo.search.call_count == 1
+    assert data["detail"] == "Search parameters are invalid: ['wrong']"

--- a/integration_tests/event/test_search.py
+++ b/integration_tests/event/test_search.py
@@ -1,6 +1,9 @@
-from fastapi.testclient import TestClient
+import logging
+
 from fastapi import status
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+
 from integration_tests.setup_db import setup_db
 
 
@@ -30,19 +33,21 @@ def test_search_event_when_not_authorised(client: TestClient, test_db: Session):
 
 
 def test_search_event_when_nothing_found(
-    client: TestClient, test_db: Session, user_header_token
+    client: TestClient, test_db: Session, user_header_token, caplog
 ):
     setup_db(test_db)
-    response = client.get(
-        "/api/v1/events/?q=lemon",
-        headers=user_header_token,
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            "/api/v1/events/?q=lemon",
+            headers=user_header_token,
+        )
+    assert response.status_code == status.HTTP_200_OK
+    assert (
+        "Events not found for terms: {'q': 'lemon', 'max_results': 500}" in caplog.text
     )
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    data = response.json()
-    assert data["detail"] == "Events not found for term: lemon"
 
 
-def test_search_event_when_db_error(
+def test_search_document_when_db_error(
     client: TestClient, test_db: Session, bad_event_repo, user_header_token
 ):
     setup_db(test_db)
@@ -51,4 +56,38 @@ def test_search_event_when_db_error(
         headers=user_header_token,
     )
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["detail"] == "Bad Repo"
     assert bad_event_repo.search.call_count == 1
+
+
+def test_search_document_with_max_results(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/?q=Amended&max_results=1",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert type(data) is list
+
+    ids_found = set([f["import_id"] for f in data])
+    assert len(ids_found) == 1
+
+    expected_ids = set(["E.0.0.2"])
+    assert ids_found.symmetric_difference(expected_ids) == set([])
+
+
+def test_search_document_when_invalid_params(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/events/?wrong=param",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    data = response.json()
+    assert data["detail"] == "Search parameters are invalid: ['wrong']"

--- a/integration_tests/family/test_search.py
+++ b/integration_tests/family/test_search.py
@@ -24,6 +24,25 @@ def test_search_family_using_q(client: TestClient, test_db: Session, user_header
     assert ids_found.symmetric_difference(expected_ids) == set([])
 
 
+def test_search_family_with_specific_param(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    response = client.get(
+        "/api/v1/families/?summary=apple",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert type(data) is list
+
+    ids_found = set([f["import_id"] for f in data])
+    assert len(ids_found) == 1
+
+    expected_ids = set(["A.0.0.2"])
+    assert ids_found.symmetric_difference(expected_ids) == set([])
+
+
 def test_search_family_with_max_results(
     client: TestClient, test_db: Session, user_header_token
 ):

--- a/integration_tests/family/test_search.py
+++ b/integration_tests/family/test_search.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from integration_tests.setup_db import setup_db
 
 
-def test_search_family(client: TestClient, test_db: Session, user_header_token):
+def test_search_family_using_q(client: TestClient, test_db: Session, user_header_token):
     setup_db(test_db)
     response = client.get(
         "/api/v1/families/?q=orange",

--- a/integration_tests/family/test_update.py
+++ b/integration_tests/family/test_update.py
@@ -218,7 +218,7 @@ def test_update_family_when_user_org_different_to_family_org(
         test_db.query(Family).filter(Family.import_id == "A.0.0.2").one()
     )
     assert db_family.title == "apple orange banana"
-    assert db_family.description == ""
+    assert db_family.description == "apple"
     assert db_family.geography_id == 1
     assert db_family.family_category == "UNFCCC"
 

--- a/integration_tests/setup_db.py
+++ b/integration_tests/setup_db.py
@@ -49,7 +49,7 @@ EXPECTED_FAMILIES = [
     {
         "import_id": "A.0.0.2",
         "title": "apple orange banana",
-        "summary": "",
+        "summary": "apple",
         "geography": "South Asia",
         "category": "UNFCCC",
         "status": "Created",

--- a/unit_tests/mocks/repos/family_repo.py
+++ b/unit_tests/mocks/repos/family_repo.py
@@ -35,7 +35,9 @@ def search(
     _maybe_timeout()
     if getattr(family_repo, "return_empty"):
         return []
-    return [create_family_dto("search1")]
+    if "title" in query_params.keys():
+        return [create_family_dto("search1")]
+    return [create_family_dto("search1"), create_family_dto("search2")]
 
 
 def update(db: Session, import_id: str, family: FamilyWriteDTO, geo_id: int) -> bool:

--- a/unit_tests/routers/test_collection.py
+++ b/unit_tests/routers/test_collection.py
@@ -3,6 +3,8 @@ Tests the routes for collection management.
 
 This uses a service mock and ensures each endpoint calls into the service.
 """
+import logging
+
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -53,15 +55,59 @@ def test_search_when_ok(client: TestClient, collection_service_mock, user_header
     assert collection_service_mock.search.call_count == 1
 
 
-def test_search_when_not_found(
+def test_search_when_invalid_params(
     client: TestClient, collection_service_mock, user_header_token
 ):
-    collection_service_mock.missing = True
-    response = client.get("/api/v1/collections/?q=stuff", headers=user_header_token)
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    response = client.get("/api/v1/collections/?wrong=yes", headers=user_header_token)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     data = response.json()
-    assert data["detail"] == "Collections not found for term: stuff"
+    assert data["detail"] == "Search parameters are invalid: ['wrong']"
+    assert collection_service_mock.search.call_count == 0
+
+
+def test_search_when_db_error(
+    client: TestClient, collection_service_mock, user_header_token
+):
+    collection_service_mock.throw_repository_error = True
+    response = client.get("/api/v1/collections/?q=error", headers=user_header_token)
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["detail"] == "bad repo"
     assert collection_service_mock.search.call_count == 1
+
+
+def test_search_when_request_timeout(
+    client: TestClient,
+    collection_service_mock,
+    user_header_token,
+    caplog,
+):
+    collection_service_mock.throw_timeout_error = True
+    with caplog.at_level(logging.INFO):
+        response = client.get(
+            "/api/v1/collections/?q=timeout", headers=user_header_token
+        )
+    assert response.status_code == status.HTTP_408_REQUEST_TIMEOUT
+    assert collection_service_mock.search.call_count == 1
+    assert (
+        "Request timed out fetching matching collections. Try adjusting your query."
+        in caplog.text
+    )
+
+
+def test_search_when_not_found(
+    client: TestClient, collection_service_mock, user_header_token, caplog
+):
+    collection_service_mock.missing = True
+    with caplog.at_level(logging.INFO):
+        response = client.get("/api/v1/collections/?q=stuff", headers=user_header_token)
+    assert response.status_code == status.HTTP_200_OK
+    response.json()
+    assert collection_service_mock.search.call_count == 1
+    assert (
+        "Collections not found for terms: {'q': 'stuff', 'max_results': 500}"
+        in caplog.text
+    )
 
 
 def test_update_when_ok(client: TestClient, collection_service_mock, user_header_token):

--- a/unit_tests/routers/test_document.py
+++ b/unit_tests/routers/test_document.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -48,15 +50,54 @@ def test_search_when_ok(client: TestClient, document_service_mock, user_header_t
     assert document_service_mock.search.call_count == 1
 
 
-def test_search_when_not_found(
+def test_search_when_invalid_params(
     client: TestClient, document_service_mock, user_header_token
 ):
-    document_service_mock.missing = True
-    response = client.get("/api/v1/documents/?q=stuff", headers=user_header_token)
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    response = client.get("/api/v1/documents/?wrong=yes", headers=user_header_token)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     data = response.json()
-    assert data["detail"] == "Documents not found for term: stuff"
+    assert data["detail"] == "Search parameters are invalid: ['wrong']"
+    assert document_service_mock.search.call_count == 0
+
+
+def test_search_when_db_error(
+    client: TestClient, document_service_mock, user_header_token
+):
+    document_service_mock.throw_repository_error = True
+    response = client.get("/api/v1/documents/?q=error", headers=user_header_token)
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["detail"] == "bad repo"
     assert document_service_mock.search.call_count == 1
+
+
+def test_search_when_request_timeout(
+    client: TestClient, document_service_mock, user_header_token, caplog
+):
+    document_service_mock.throw_timeout_error = True
+    with caplog.at_level(logging.INFO):
+        response = client.get("/api/v1/documents/?q=timeout", headers=user_header_token)
+    assert response.status_code == status.HTTP_408_REQUEST_TIMEOUT
+    assert document_service_mock.search.call_count == 1
+    assert (
+        "Request timed out fetching matching documents. Try adjusting your query."
+        in caplog.text
+    )
+
+
+def test_search_when_not_found(
+    client: TestClient, document_service_mock, user_header_token, caplog
+):
+    document_service_mock.missing = True
+    with caplog.at_level(logging.INFO):
+        response = client.get("/api/v1/documents/?q=stuff", headers=user_header_token)
+    assert response.status_code == status.HTTP_200_OK
+    response.json()
+    assert document_service_mock.search.call_count == 1
+    assert (
+        "Documents not found for terms: {'q': 'stuff', 'max_results': 500}"
+        in caplog.text
+    )
 
 
 def test_update_when_ok(client: TestClient, document_service_mock, user_header_token):

--- a/unit_tests/routers/test_event.py
+++ b/unit_tests/routers/test_event.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from fastapi import status
 from fastapi.encoders import jsonable_encoder
@@ -47,15 +49,56 @@ def test_search_when_ok(client: TestClient, event_service_mock, user_header_toke
     assert event_service_mock.search.call_count == 1
 
 
-def test_search_when_not_found(
+def test_search_when_invalid_params(
     client: TestClient, event_service_mock, user_header_token
 ):
-    event_service_mock.missing = True
-    response = client.get("/api/v1/events/?q=stuff", headers=user_header_token)
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    response = client.get("/api/v1/events/?wrong=yes", headers=user_header_token)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
     data = response.json()
-    assert data["detail"] == "Events not found for term: stuff"
+    assert data["detail"] == "Search parameters are invalid: ['wrong']"
+    assert event_service_mock.search.call_count == 0
+
+
+def test_search_when_db_error(
+    client: TestClient, event_service_mock, user_header_token
+):
+    event_service_mock.throw_repository_error = True
+    response = client.get("/api/v1/events/?q=error", headers=user_header_token)
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    data = response.json()
+    assert data["detail"] == "bad repo"
     assert event_service_mock.search.call_count == 1
+
+
+def test_search_when_request_timeout(
+    client: TestClient,
+    event_service_mock,
+    user_header_token,
+    caplog,
+):
+    event_service_mock.throw_timeout_error = True
+    with caplog.at_level(logging.INFO):
+        response = client.get("/api/v1/events/?q=timeout", headers=user_header_token)
+    assert response.status_code == status.HTTP_408_REQUEST_TIMEOUT
+    assert event_service_mock.search.call_count == 1
+    assert (
+        "Request timed out fetching matching events. Try adjusting your query."
+        in caplog.text
+    )
+
+
+def test_search_when_not_found(
+    client: TestClient, event_service_mock, user_header_token, caplog
+):
+    event_service_mock.missing = True
+    with caplog.at_level(logging.INFO):
+        response = client.get("/api/v1/events/?q=stuff", headers=user_header_token)
+    assert response.status_code == status.HTTP_200_OK
+    response.json()
+    assert event_service_mock.search.call_count == 1
+    assert (
+        "Events not found for terms: {'q': 'stuff', 'max_results': 500}" in caplog.text
+    )
 
 
 def test_create_when_ok(client: TestClient, event_service_mock, user_header_token):

--- a/unit_tests/service/test_document_service.py
+++ b/unit_tests/service/test_document_service.py
@@ -1,7 +1,8 @@
 import pytest
-from app.model.document import DocumentReadDTO, DocumentWriteDTO
+
 import app.service.document as doc_service
 from app.errors import RepositoryError, ValidationError
+from app.model.document import DocumentReadDTO, DocumentWriteDTO
 from unit_tests.helpers.document import create_document_create_dto
 
 
@@ -62,15 +63,29 @@ def test_get_raises_when_invalid_id(document_repo_mock):
 
 
 def test_search(document_repo_mock):
-    result = doc_service.search("two")
+    result = doc_service.search({"q": "two"})
     assert result is not None
     assert len(result) == 1
     assert document_repo_mock.search.call_count == 1
 
 
-def test_search_when_missing(document_repo_mock):
+def test_search_db_error(document_repo_mock):
+    document_repo_mock.throw_repository_error = True
+    with pytest.raises(RepositoryError):
+        doc_service.search({"q": "error"})
+    assert document_repo_mock.search.call_count == 1
+
+
+def test_search_request_timeout(document_repo_mock):
+    document_repo_mock.throw_timeout_error = True
+    with pytest.raises(TimeoutError):
+        doc_service.search({"q": "timeout"})
+    assert document_repo_mock.search.call_count == 1
+
+
+def test_search_missing(document_repo_mock):
     document_repo_mock.return_empty = True
-    result = doc_service.search("empty")
+    result = doc_service.search({"q": "empty"})
     assert result is not None
     assert len(result) == 0
     assert document_repo_mock.search.call_count == 1

--- a/unit_tests/service/test_event_service.py
+++ b/unit_tests/service/test_event_service.py
@@ -1,8 +1,9 @@
 import pytest
+
 import app.service.event as event_service
 from app.errors import RepositoryError, ValidationError
-from unit_tests.helpers.event import create_event_create_dto
 from app.model.event import EventReadDTO, EventWriteDTO
+from unit_tests.helpers.event import create_event_create_dto
 
 
 def _to_write_dto(dto: EventReadDTO) -> EventWriteDTO:
@@ -42,15 +43,29 @@ def test_get_raises_when_invalid_id(event_repo_mock):
 
 
 def test_search(event_repo_mock):
-    result = event_service.search("two")
+    result = event_service.search({"q": "two"})
     assert result is not None
     assert len(result) == 1
     assert event_repo_mock.search.call_count == 1
 
 
-def test_search_when_missing(event_repo_mock):
+def test_search_db_error(event_repo_mock):
+    event_repo_mock.throw_repository_error = True
+    with pytest.raises(RepositoryError):
+        event_service.search({"q": "error"})
+    assert event_repo_mock.search.call_count == 1
+
+
+def test_search_request_timeout(event_repo_mock):
+    event_repo_mock.throw_timeout_error = True
+    with pytest.raises(TimeoutError):
+        event_service.search({"q": "timeout"})
+    assert event_repo_mock.search.call_count == 1
+
+
+def test_search_missing(event_repo_mock):
     event_repo_mock.return_empty = True
-    result = event_service.search("empty")
+    result = event_service.search({"q": "empty"})
     assert result is not None
     assert len(result) == 0
     assert event_repo_mock.search.call_count == 1

--- a/unit_tests/service/test_family_service.py
+++ b/unit_tests/service/test_family_service.py
@@ -72,6 +72,13 @@ def test_get_raises_when_invalid_id(family_repo_mock):
 def test_search(family_repo_mock):
     result = family_service.search({"q": "two"})
     assert result is not None
+    assert len(result) == 2
+    assert family_repo_mock.search.call_count == 1
+
+
+def test_search_on_specific_field(family_repo_mock):
+    result = family_service.search({"title": "one"})
+    assert result is not None
     assert len(result) == 1
     assert family_repo_mock.search.call_count == 1
 


### PR DESCRIPTION
# Description

Please include:

- Extended search for collection, event, and document entities.
- Returned 200 instead of 404 when no matching entries found in DB.
- Added tests for all of this.
-  Linear ticket [PDCT-654](https://linear.app/climate-policy-radar/issue/PDCT-654/return-empty-200-on-all-search-entities-when-no-results-found)

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Added unit and integration tests.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
