### PR TITLE
Bugfix/pdct 670 blanking language causes problems

### DIFF
--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional, Tuple, Union, cast
 
 from sqlalchemy import Column, and_, func
+from sqlalchemy import delete as db_delete
 from sqlalchemy import insert as db_insert
 from sqlalchemy import update as db_update
 from sqlalchemy.exc import NoResultFound, OperationalError
@@ -275,6 +276,11 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
                 language_id=new_language.id,
                 source=LanguageSource.USER,
             )
+        commands.append(command)
+    else:
+        command = db_delete(PhysicalDocumentLanguage).where(
+            PhysicalDocumentLanguage.document_id == original_fd.physical_document_id
+        )
         commands.append(command)
 
     for c in commands:

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -339,9 +339,6 @@ def create(db: Session, document: DocumentCreateDTO) -> str:
         # Update the FamilyDocument with the new PhysicalDocument id
         family_doc.physical_document_id = phys_doc.id
 
-        # Add the language link with the new PhysicalDocument id
-        language.document_id = phys_doc.id
-
         # Generate the import_id for the new document
         org = family_repo.get_organisation(db, cast(str, family_doc.family_import_id))
         if org is None:
@@ -357,7 +354,12 @@ def create(db: Session, document: DocumentCreateDTO) -> str:
 
         # Add the new document and its language link
         db.add(family_doc)
-        db.add(language)
+
+        # Add the language link with the new PhysicalDocument id
+        if language.language_id is not None:
+            language.document_id = phys_doc.id
+            db.add(language)
+
         db.flush()
 
         # Finally the slug

--- a/integration_tests/document/test_create.py
+++ b/integration_tests/document/test_create.py
@@ -111,9 +111,9 @@ def test_create_document_null_user_language_name(
     language = (
         test_db.query(PhysicalDocumentLanguage)
         .filter(PhysicalDocumentLanguage.document_id == actual_fd.physical_document_id)
-        .one()
+        .one_or_none()
     )
-    assert language is not None
+    assert language is None
 
     actual_pd = (
         test_db.query(PhysicalDocument)

--- a/unit_tests/helpers/document.py
+++ b/unit_tests/helpers/document.py
@@ -18,7 +18,7 @@ def create_document_create_dto(
         type="Law",
         title=title,
         source_url="source",
-        user_language_name="Ghotuo",
+        user_language_name=user_language_name,
     )
 
 


### PR DESCRIPTION
# Description

- Remove entry from language table if user language in doc update is None.
- Only add language link on document create if language is not null.
- Added integration tests for these.

Linear ticket [PDCT-670](https://linear.app/climate-policy-radar/issue/PDCT-670/blanking-language-causes-problems)

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

New integration tests added.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
