### PR TITLE
PDCT-684/create_documents_in_the_published_state_for_now

### DIFF
--- a/app/clients/db/models/law_policy/family.py
+++ b/app/clients/db/models/law_policy/family.py
@@ -207,7 +207,7 @@ class FamilyDocument(Base):
     variant_name = sa.Column(sa.ForeignKey(Variant.variant_name), nullable=True)
     document_status = sa.Column(
         sa.Enum(DocumentStatus),
-        default=DocumentStatus.CREATED,
+        default=DocumentStatus.PUBLISHED,
         nullable=False,
     )
     document_type = sa.Column(sa.ForeignKey(FamilyDocumentType.name), nullable=True)


### PR DESCRIPTION
# Description

Please include:

Change status default value for Documents on create and add test.

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Including one integrity test case.

## Reviewer Checklist

- [x] The PR represents a single feature (small drive-by fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
