### PR TITLE
PDCT-762 Changed default doc status back to CREATED.

### DIFF
--- a/app/clients/db/models/law_policy/family.py
+++ b/app/clients/db/models/law_policy/family.py
@@ -206,9 +206,7 @@ class FamilyDocument(Base):
     import_id = sa.Column(sa.Text, primary_key=True)
     variant_name = sa.Column(sa.ForeignKey(Variant.variant_name), nullable=True)
     document_status = sa.Column(
-        sa.Enum(DocumentStatus),
-        default=DocumentStatus.PUBLISHED,
-        nullable=False,
+        sa.Enum(DocumentStatus), default=DocumentStatus.CREATED, nullable=False
     )
     document_type = sa.Column(sa.ForeignKey(FamilyDocumentType.name), nullable=True)
     document_role = sa.Column(sa.ForeignKey(FamilyDocumentRole.name), nullable=True)

--- a/integration_tests/document/test_create.py
+++ b/integration_tests/document/test_create.py
@@ -244,7 +244,7 @@ def test_create_document_when_invalid_variant(
     assert '(Invalid) is not present in table "variant"' in data["detail"]
 
 
-def test_document_status_is_published_on_create(
+def test_document_status_is_created_on_create(
     client: TestClient, test_db: Session, user_header_token
 ):
     setup_db(test_db)

--- a/integration_tests/document/test_create.py
+++ b/integration_tests/document/test_create.py
@@ -263,4 +263,4 @@ def test_document_status_is_published_on_create(
     )
 
     assert actual_fd is not None
-    assert actual_fd.document_status is DocumentStatus.PUBLISHED
+    assert actual_fd.document_status is DocumentStatus.CREATED


### PR DESCRIPTION
# Description

We jumped the gun changing the default doc status to PUBLISHED. As part of the single production truth work, we need the default to be CREATED.

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Updated integration test.

## Reviewer Checklist

- [x] The PR represents a single feature (small drive-by fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
