### PR TITLE
Pdct 820/adding a family document which we dont have a url for

### DIFF
--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -62,4 +62,4 @@ fi
 
 new_version_num=${new_tag#v} # Remove the leading 'v'
 git tag -a "${new_tag}" -m "Version ${new_version_num}"
-# git push origin "${new_tag}"
+git push origin "${new_tag}"

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -62,4 +62,4 @@ fi
 
 new_version_num=${new_tag#v} # Remove the leading 'v'
 git tag -a "${new_tag}" -m "Version ${new_version_num}"
-git push origin "${new_tag}"
+# git push origin "${new_tag}"

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -21,6 +21,7 @@ jobs:
               })
             ).data[0];
 
+    - uses: fregante/setup-git-user@v2
     - uses: actions/checkout@v2
     - name: Run Auto-tagging
       # User controlled input needs to be santitised beforehand e.g., by adding an

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -21,8 +21,8 @@ jobs:
               })
             ).data[0];
 
-    - uses: fregante/setup-git-user@v2
     - uses: actions/checkout@v2
+    - uses: fregante/setup-git-user@v2
     - name: Run Auto-tagging
       # User controlled input needs to be santitised beforehand e.g., by adding an
       # intermediate env var to prevent the workflow being exposed to a critical

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -22,7 +22,6 @@ jobs:
             ).data[0];
 
     - uses: actions/checkout@v2
-    - uses: fregante/setup-git-user@v2
     - name: Run Auto-tagging
       # User controlled input needs to be santitised beforehand e.g., by adding an
       # intermediate env var to prevent the workflow being exposed to a critical

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -1,9 +1,9 @@
 name: main push git autotag
 
 on:
-  push:
-    branches:
-      - main
+  push #:
+    # branches:
+    #   - main
 
 jobs:
   auto-git-tag:
@@ -22,6 +22,7 @@ jobs:
             ).data[0];
 
     - uses: actions/checkout@v2
+    - uses: fregante/setup-git-user@v2
     - name: Run Auto-tagging
       # User controlled input needs to be santitised beforehand e.g., by adding an
       # intermediate env var to prevent the workflow being exposed to a critical

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -1,9 +1,9 @@
 name: main push git autotag
 
 on:
-  push #:
-    # branches:
-    #   - main
+  push:
+    branches:
+      - main
 
 jobs:
   auto-git-tag:

--- a/app/model/document.py
+++ b/app/model/document.py
@@ -55,7 +55,7 @@ class DocumentCreateDTO(BaseModel):
 
     # From PhysicalDocument
     title: str
-    source_url: AnyHttpUrl
+    source_url: Optional[AnyHttpUrl]
     user_language_name: Optional[str]
 
 

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -125,7 +125,7 @@ def _document_tuple_from_dto(db: Session, dto: DocumentCreateDTO) -> CreateObjec
     phys_doc = PhysicalDocument(
         id=None,
         title=dto.title,
-        source_url=str(dto.source_url),
+        source_url=cast(str, dto.source_url) if dto.source_url is not None else None,
     )
     return language, fam_doc, phys_doc
 

--- a/unit_tests/helpers/document.py
+++ b/unit_tests/helpers/document.py
@@ -10,6 +10,7 @@ def create_document_create_dto(
     family_import_id="test.family.1.0",
     title: str = "title",
     variant_name: Optional[str] = "Original Language",
+    source_url: Optional[AnyHttpUrl] = cast(AnyHttpUrl, "http://source"),
     user_language_name: Optional[str] = None,
 ) -> DocumentCreateDTO:
     return DocumentCreateDTO(
@@ -18,7 +19,7 @@ def create_document_create_dto(
         role="MAIN",
         type="Law",
         title=title,
-        source_url=cast(AnyHttpUrl, "http://source"),
+        source_url=source_url,
         user_language_name=user_language_name,
     )
 


### PR DESCRIPTION
# Description

Linear ticket [PDCT-820](https://linear.app/climate-policy-radar/issue/PDCT-820/adding-a-family-document-which-we-dont-have-a-url-for)
- Make adding a source URL in the admin backend optional

- Driveby add setup Git user action to GitHub workflow to enable auto-tagging

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
