### PR TITLE
Fix makefile command for building and tagging docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ test_bashscripts: build_bats
 	docker run --rm -v "${PWD}/.github:/code" bats-with-helpers:latest /code/tests/
 
 build:
+	docker build -t navigator-admin-backend .
+
+build_local:
 	docker compose build
 
 unit_test:


### PR DESCRIPTION
# Description

The makefile command was changed during the db-client rewrite from `docker build -t navigator-admin-backend .` to `docker compose build`, breaking the CI tagging and resulting in rollbacks in AWS.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Manually tested.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
