### PR TITLE
Run semver Docker tagging after git autotagging and on manual tag.

### DIFF
--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -62,4 +62,4 @@ fi
 
 new_version_num=${new_tag#v} # Remove the leading 'v'
 git tag -a "${new_tag}" -m "Version ${new_version_num}"
-git push origin "${new_tag}"
+git push --tags origin "${new_tag}"

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - v*
 
+  workflow_run:
+    workflows: ["main push git autotag"]
+    types:
+      - completed
+
 env:
   DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
# Description

Configure semver autotagging to run after git auto tagging.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Reviewer Checklist

- [x] The PR represents a single feature (small drive-by fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
