### PR TITLE
Fix auto semver tagging

### DIFF
--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -62,3 +62,4 @@ fi
 new_version_num=${new_tag#v} # Remove the leading 'v'
 # git tag -a "${new_tag}" -m "Version ${new_version_num}"
 # git push --tags origin "${new_tag}"
+echo "${new_tag}"

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -1,65 +1,66 @@
 #!/bin/bash
 set -e
 
-script_folder=$(dirname "${BASH_SOURCE[0]}")
-source "${script_folder}"/funcs.sh
+# script_folder=$(dirname "${BASH_SOURCE[0]}")
+# source "${script_folder}"/funcs.sh
 
-# Get the latest Git tag.
-latest_tag=$(get_latest_tag)
-if [ -z "${latest_tag}" ]; then
-	echo "No tags found. Please create first tag manually to enable auto-tagging."
-	exit 1
-fi
-echo "Latest tag: ${latest_tag}"
+# # Get the latest Git tag.
+# latest_tag=$(get_latest_tag)
+# if [ -z "${latest_tag}" ]; then
+# 	echo "No tags found. Please create first tag manually to enable auto-tagging."
+# 	exit 1
+# fi
+# echo "Latest tag: ${latest_tag}"
 
-pr_body="$1"
+# pr_body="$1"
 
-# Get selected versioning checkboxes.
-is_patch=$(is_patch_selected "${pr_body}")
-is_minor=$(is_minor_selected "${pr_body}")
-is_major=$(is_major_selected "${pr_body}")
+# # Get selected versioning checkboxes.
+# is_patch=$(is_patch_selected "${pr_body}")
+# is_minor=$(is_minor_selected "${pr_body}")
+# is_major=$(is_major_selected "${pr_body}")
 
-pr_number="$2"
+# pr_number="$2"
 
-if { [[ ${is_minor} == true ]] && [[ ${is_patch} == true ]]; } ||
-	{ [[ ${is_minor} == true ]] && [[ ${is_major} == true ]]; } ||
-	{ [[ ${is_patch} == true ]] && [[ ${is_major} == true ]]; }; then
-	echo "Ambiguous tag information in body of pull request #${pr_number}. Auto-tagging will use most senior version option selected."
-fi
+# if { [[ ${is_minor} == true ]] && [[ ${is_patch} == true ]]; } ||
+# 	{ [[ ${is_minor} == true ]] && [[ ${is_major} == true ]]; } ||
+# 	{ [[ ${is_patch} == true ]] && [[ ${is_major} == true ]]; }; then
+# 	echo "Ambiguous tag information in body of pull request #${pr_number}. Auto-tagging will use most senior version option selected."
+# fi
 
-# Extract the version numbers from the tag
-version_numbers=${latest_tag#v}       # Remove the leading 'v'
-version_numbers=${version_numbers%-*} # Remove the trailing '-beta'
-major_version=$(get_major "${version_numbers}")
-minor_version=$(get_minor "${version_numbers}")
-patch_version=$(get_patch "${version_numbers}")
-maturity=$(get_maturity "${latest_tag}")
-if [ ! -z "${maturity}" ]; then
-	maturity="-${maturity}"
-fi
+# # Extract the version numbers from the tag
+# version_numbers=${latest_tag#v}       # Remove the leading 'v'
+# version_numbers=${version_numbers%-*} # Remove the trailing '-beta'
+# major_version=$(get_major "${version_numbers}")
+# minor_version=$(get_minor "${version_numbers}")
+# patch_version=$(get_patch "${version_numbers}")
+# maturity=$(get_maturity "${latest_tag}")
+# if [ ! -z "${maturity}" ]; then
+# 	maturity="-${maturity}"
+# fi
 
-# Auto-tag based on most senior version selected.
-if [[ ${is_major} == true ]]; then
-	new_major_version=$(increment "${major_version}")
-	new_tag=v${new_major_version}.0.0${maturity}
-	echo "Tagging as new major version ${new_tag}..."
-elif [[ ${is_minor} == true ]]; then
-	new_minor_version=$(increment "${minor_version}")
-	new_tag="v${major_version}.${new_minor_version}.0${maturity}"
-	echo "Tagging as new minor version ${new_tag}..."
-else
-	new_patch_version=$(increment "${patch_version}")
-	new_tag=v${major_version}.${minor_version}.${new_patch_version}${maturity}
-	echo "Tagging as new patch ${new_tag}..."
-fi
+# # Auto-tag based on most senior version selected.
+# if [[ ${is_major} == true ]]; then
+# 	new_major_version=$(increment "${major_version}")
+# 	new_tag=v${new_major_version}.0.0${maturity}
+# 	echo "Tagging as new major version ${new_tag}..."
+# elif [[ ${is_minor} == true ]]; then
+# 	new_minor_version=$(increment "${minor_version}")
+# 	new_tag="v${major_version}.${new_minor_version}.0${maturity}"
+# 	echo "Tagging as new minor version ${new_tag}..."
+# else
+# 	new_patch_version=$(increment "${patch_version}")
+# 	new_tag=v${major_version}.${minor_version}.${new_patch_version}${maturity}
+# 	echo "Tagging as new patch ${new_tag}..."
+# fi
 
-# If multiple have been checked or none have been checked, don't auto tag.
-if { [[ ${is_minor} == false ]] && [[ ${is_patch} == false ]] && [[ ${is_major} == false ]]; }; then
-	echo "No tag information found in body of pull request #${pr_number}. Auto-tagging failed..."
-	exit 1
-fi
+# # If multiple have been checked or none have been checked, don't auto tag.
+# if { [[ ${is_minor} == false ]] && [[ ${is_patch} == false ]] && [[ ${is_major} == false ]]; }; then
+# 	echo "No tag information found in body of pull request #${pr_number}. Auto-tagging failed..."
+# 	exit 1
+# fi
 
-new_version_num=${new_tag#v} # Remove the leading 'v'
-# git tag -a "${new_tag}" -m "Version ${new_version_num}"
-# git push --tags origin "${new_tag}"
-echo "${new_tag}"
+# new_version_num=${new_tag#v} # Remove the leading 'v'
+# # git tag -a "${new_tag}" -m "Version ${new_version_num}"
+# # git push --tags origin "${new_tag}"
+# echo "${new_tag}"
+echo "v1.0.9-beta"

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -5,8 +5,7 @@ script_folder=$(dirname "${BASH_SOURCE[0]}")
 source "${script_folder}"/funcs.sh
 
 # Get the latest Git tag.
-git fetch --prune --unshallow --tags # This is needed - without it no tags are found.
-latest_tag=$(git tag --list 'v*' --sort=-authordate --merged | head -n1)
+latest_tag=$(get_latest_tag)
 if [ -z "${latest_tag}" ]; then
 	echo "No tags found. Please create first tag manually to enable auto-tagging."
 	exit 1

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -62,4 +62,4 @@ fi
 
 new_version_num=${new_tag#v} # Remove the leading 'v'
 git tag -a "${new_tag}" -m "Version ${new_version_num}"
-git push origin "${new_tag}"
+git push --tags origin "${new_tag}"

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -63,4 +63,4 @@ set -e
 # # git tag -a "${new_tag}" -m "Version ${new_version_num}"
 # # git push --tags origin "${new_tag}"
 # echo "${new_tag}"
-echo "v1.0.9-beta"
+echo "v1.0.7-beta"

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -60,5 +60,5 @@ if { [[ ${is_minor} == false ]] && [[ ${is_patch} == false ]] && [[ ${is_major} 
 fi
 
 new_version_num=${new_tag#v} # Remove the leading 'v'
-git tag -a "${new_tag}" -m "Version ${new_version_num}"
-git push --tags origin "${new_tag}"
+# git tag -a "${new_tag}" -m "Version ${new_version_num}"
+# git push --tags origin "${new_tag}"

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -1,66 +1,65 @@
 #!/bin/bash
 set -e
 
-# script_folder=$(dirname "${BASH_SOURCE[0]}")
-# source "${script_folder}"/funcs.sh
+script_folder=$(dirname "${BASH_SOURCE[0]}")
+source "${script_folder}"/funcs.sh
 
-# # Get the latest Git tag.
-# latest_tag=$(get_latest_tag)
-# if [ -z "${latest_tag}" ]; then
-# 	echo "No tags found. Please create first tag manually to enable auto-tagging."
-# 	exit 1
-# fi
-# echo "Latest tag: ${latest_tag}"
+# Get the latest Git tag.
+latest_tag=$(get_latest_tag)
+if [ -z "${latest_tag}" ]; then
+	echo "No tags found. Please create first tag manually to enable auto-tagging."
+	exit 1
+fi
+echo "Latest tag: ${latest_tag}"
 
-# pr_body="$1"
+pr_body="$1"
 
-# # Get selected versioning checkboxes.
-# is_patch=$(is_patch_selected "${pr_body}")
-# is_minor=$(is_minor_selected "${pr_body}")
-# is_major=$(is_major_selected "${pr_body}")
+# Get selected versioning checkboxes.
+is_patch=$(is_patch_selected "${pr_body}")
+is_minor=$(is_minor_selected "${pr_body}")
+is_major=$(is_major_selected "${pr_body}")
 
-# pr_number="$2"
+pr_number="$2"
 
-# if { [[ ${is_minor} == true ]] && [[ ${is_patch} == true ]]; } ||
-# 	{ [[ ${is_minor} == true ]] && [[ ${is_major} == true ]]; } ||
-# 	{ [[ ${is_patch} == true ]] && [[ ${is_major} == true ]]; }; then
-# 	echo "Ambiguous tag information in body of pull request #${pr_number}. Auto-tagging will use most senior version option selected."
-# fi
+if { [[ ${is_minor} == true ]] && [[ ${is_patch} == true ]]; } ||
+	{ [[ ${is_minor} == true ]] && [[ ${is_major} == true ]]; } ||
+	{ [[ ${is_patch} == true ]] && [[ ${is_major} == true ]]; }; then
+	echo "Ambiguous tag information in body of pull request #${pr_number}. Auto-tagging will use most senior version option selected."
+fi
 
-# # Extract the version numbers from the tag
-# version_numbers=${latest_tag#v}       # Remove the leading 'v'
-# version_numbers=${version_numbers%-*} # Remove the trailing '-beta'
-# major_version=$(get_major "${version_numbers}")
-# minor_version=$(get_minor "${version_numbers}")
-# patch_version=$(get_patch "${version_numbers}")
-# maturity=$(get_maturity "${latest_tag}")
-# if [ ! -z "${maturity}" ]; then
-# 	maturity="-${maturity}"
-# fi
+# Extract the version numbers from the tag
+version_numbers=${latest_tag#v}       # Remove the leading 'v'
+version_numbers=${version_numbers%-*} # Remove the trailing '-beta'
+major_version=$(get_major "${version_numbers}")
+minor_version=$(get_minor "${version_numbers}")
+patch_version=$(get_patch "${version_numbers}")
+maturity=$(get_maturity "${latest_tag}")
+if [ ! -z "${maturity}" ]; then
+	maturity="-${maturity}"
+fi
 
-# # Auto-tag based on most senior version selected.
-# if [[ ${is_major} == true ]]; then
-# 	new_major_version=$(increment "${major_version}")
-# 	new_tag=v${new_major_version}.0.0${maturity}
-# 	echo "Tagging as new major version ${new_tag}..."
-# elif [[ ${is_minor} == true ]]; then
-# 	new_minor_version=$(increment "${minor_version}")
-# 	new_tag="v${major_version}.${new_minor_version}.0${maturity}"
-# 	echo "Tagging as new minor version ${new_tag}..."
-# else
-# 	new_patch_version=$(increment "${patch_version}")
-# 	new_tag=v${major_version}.${minor_version}.${new_patch_version}${maturity}
-# 	echo "Tagging as new patch ${new_tag}..."
-# fi
+# Auto-tag based on most senior version selected.
+if [[ ${is_major} == true ]]; then
+	new_major_version=$(increment "${major_version}")
+	new_tag=v${new_major_version}.0.0${maturity}
+	echo "Tagging as new major version ${new_tag}..."
+elif [[ ${is_minor} == true ]]; then
+	new_minor_version=$(increment "${minor_version}")
+	new_tag="v${major_version}.${new_minor_version}.0${maturity}"
+	echo "Tagging as new minor version ${new_tag}..."
+else
+	new_patch_version=$(increment "${patch_version}")
+	new_tag=v${major_version}.${minor_version}.${new_patch_version}${maturity}
+	echo "Tagging as new patch ${new_tag}..."
+fi
 
-# # If multiple have been checked or none have been checked, don't auto tag.
-# if { [[ ${is_minor} == false ]] && [[ ${is_patch} == false ]] && [[ ${is_major} == false ]]; }; then
-# 	echo "No tag information found in body of pull request #${pr_number}. Auto-tagging failed..."
-# 	exit 1
-# fi
+# If multiple have been checked or none have been checked, don't auto tag.
+if { [[ ${is_minor} == false ]] && [[ ${is_patch} == false ]] && [[ ${is_major} == false ]]; }; then
+	echo "No tag information found in body of pull request #${pr_number}. Auto-tagging failed..."
+	exit 1
+fi
 
-# new_version_num=${new_tag#v} # Remove the leading 'v'
-# # git tag -a "${new_tag}" -m "Version ${new_version_num}"
-# # git push --tags origin "${new_tag}"
-# echo "${new_tag}"
-echo "v1.0.7-beta"
+new_version_num=${new_tag#v} # Remove the leading 'v'
+git tag -a "${new_tag}" -m "Version ${new_version_num}"
+git push --tags origin "${new_tag}"
+echo "${new_tag}"

--- a/.github/funcs.sh
+++ b/.github/funcs.sh
@@ -108,6 +108,6 @@ is_major_selected() {
 
 get_latest_tag() {
 	git fetch --prune --unshallow --tags # This is needed - without it no tags are found.
-	latest_tag=$(git tag --list 'v*' --sort=-creatordate --merged | head -n1)
+	latest_tag=$(git tag --list 'v*' --sort=-creatordate | head -n1)
 	echo "${latest_tag}"
 }

--- a/.github/funcs.sh
+++ b/.github/funcs.sh
@@ -73,7 +73,7 @@ get_docker_tags() {
 }
 
 # Auto-tag funcs.
-is_valid_git_tag() {
+is_valid_tag_name() {
 	if [[ $1 =~ v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*) ]]; then
 		return 0
 	else
@@ -104,4 +104,10 @@ is_minor_selected() {
 is_major_selected() {
 	local phrase="Major version"
 	is_selected "$1" "${phrase}"
+}
+
+get_latest_tag() {
+	git fetch --prune --unshallow --tags # This is needed - without it no tags are found.
+	latest_tag=$(git tag --list 'v*' --sort=-creatordate --merged | head -n1)
+	echo "${latest_tag}"
 }

--- a/.github/retag-and-push.sh
+++ b/.github/retag-and-push.sh
@@ -45,6 +45,7 @@ if [[ -n "${NEW_TAG}" ]]; then
         semver="${NEW_TAG/v/}"
         echo "Detected Tag: ${semver}"
         process_tagged_version ${semver}
+        exit 0
     else
         echo "New tag ${NEW_TAG} is not a valid tag name"
         exit 1

--- a/.github/retag-and-push.sh
+++ b/.github/retag-and-push.sh
@@ -36,6 +36,9 @@ process_tagged_version() {
 project="$1"
 image_tag="$2"
 
+name=$(clean_string "${DOCKER_REGISTRY}/${project}")
+input_image="${project}:${image_tag}"
+
 if [[ -n "${NEW_TAG}" ]]; then
     if is_valid_tag_name ${NEW_TAG} ; then
         # push `semver` tagged image
@@ -51,9 +54,6 @@ fi
 # login
 # This should now be performed as a GA
 # See: https://docs.docker.com/build/ci/github-actions/#step-three-define-the-workflow-steps
-
-name=$(clean_string "${DOCKER_REGISTRY}/${project}")
-input_image="${project}:${image_tag}"
 
 echo "-------------"
 echo "Input       : ${project}:${image_tag}"
@@ -77,7 +77,6 @@ if [[ "${GITHUB_REF}" == "refs/heads"* ]]; then
     branch="${GITHUB_REF/refs\/heads\//}"
     echo "Detected Branch: ${branch}"
 
-
     # Only update latest if on main
     if [[ "${branch}" = "main" ]]; then
         # push `latest` tag
@@ -90,11 +89,13 @@ if [[ "${GITHUB_REF}" == "refs/heads"* ]]; then
         docker_tag "${input_image}" "${name}:${branch}-${short_sha}"
         docker push "${name}:${branch}-${short_sha}"
     fi
+
 elif is_tagged_version ${GITHUB_REF} ; then
     # push `semver` tagged image
     semver="${GITHUB_REF/refs\/tags\/v/}"
     echo "Detected Tag: ${semver}"
     process_tagged_version ${semver}
+
 else
     echo "${GITHUB_REF} is neither a branch head nor valid semver tag"
     echo "Assuming '${GITHUB_HEAD_REF}' is a branch"

--- a/.github/retag-and-push.sh
+++ b/.github/retag-and-push.sh
@@ -17,6 +17,9 @@ fi
 
 [ "${DOCKER_REGISTRY}" == "" ] && (echo "DOCKER_REGISTRY is not set" ; exit 1)
 
+project="$1"
+image_tag="$2"
+
 docker_tag() {
     echo "Re-tagging $1 -> $2"
     docker tag $1 $2
@@ -32,9 +35,6 @@ process_tagged_version() {
         docker push "${tag}"
     done
 }
-
-project="$1"
-image_tag="$2"
 
 name=$(clean_string "${DOCKER_REGISTRY}/${project}")
 input_image="${project}:${image_tag}"

--- a/.github/retag-and-push.sh
+++ b/.github/retag-and-push.sh
@@ -17,6 +17,22 @@ fi
 
 [ "${DOCKER_REGISTRY}" == "" ] && (echo "DOCKER_REGISTRY is not set" ; exit 1)
 
+docker_tag() {
+    echo "Re-tagging $1 -> $2"
+    docker tag $1 $2
+}
+
+process_tagged_version() {
+    local tag_array
+    semver=$1
+    get_docker_tags tag_array ${name} ${semver}
+
+    for tag in "${tag_array[@]}" ; do
+        docker_tag "${input_image}" ${tag}
+        docker push "${tag}"
+    done
+}
+
 project="$1"
 image_tag="$2"
 
@@ -47,22 +63,6 @@ echo "GitHeadRef  : ${GITHUB_HEAD_REF}"
 echo "Branch      : ${GITHUB_REF/refs\/heads\//}"
 echo "Repo Tag    : ${name}"
 echo "-------------"
-
-docker_tag() {
-    echo "Re-tagging $1 -> $2"
-    docker tag $1 $2
-}
-
-process_tagged_version() {
-    local tag_array
-    semver=$1
-    get_docker_tags tag_array ${name} ${semver}
-
-    for tag in "${tag_array[@]}" ; do
-        docker_tag "${input_image}" ${tag}
-        docker push "${tag}"
-    done
-}
 
 timestamp=$(date --utc -Iseconds | cut -c1-19 | tr -c '[0-9]T\n' '-')
 short_sha=${GITHUB_SHA:0:8}

--- a/.github/retag-and-push.sh
+++ b/.github/retag-and-push.sh
@@ -20,6 +20,18 @@ fi
 project="$1"
 image_tag="$2"
 
+if [[ -n "${NEW_TAG}" ]]; then
+    if is_valid_tag_name ${NEW_TAG} ; then
+        # push `semver` tagged image
+        semver="${NEW_TAG/v/}"
+        echo "Detected Tag: ${semver}"
+        process_tagged_version ${semver}
+    else
+        echo "New tag ${NEW_TAG} is not a valid tag name"
+        exit 1
+    fi
+fi
+
 # login
 # This should now be performed as a GA
 # See: https://docs.docker.com/build/ci/github-actions/#step-three-define-the-workflow-steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,6 @@ jobs:
         run: |
           poetry run pre-commit run --all-files
 
-      - name: Use .env.example
-        run: cp .env.example .env
-
       - name: Build
         run: make build
 

--- a/.github/workflows/main-push-autotag.yml
+++ b/.github/workflows/main-push-autotag.yml
@@ -1,4 +1,4 @@
-name: main push git autotag
+name: main push autotag
 
 on:
   push:

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -65,4 +65,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          docker pull ${DOCKER_REGISTRY}/navigator-admin-backend:main-d62fb12f
           .github/retag-and-push.sh navigator-admin-backend main-d62fb12f

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -65,4 +65,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          .github/retag-and-push.sh navigator-admin-backend main-${GITHUB_SHA::8}
+          .github/retag-and-push.sh navigator-admin-backend main-d62fb12f

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -65,4 +65,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          .github/retag-and-push.sh navigator-admin-backend ${NEW_TAG}
+          .github/retag-and-push.sh navigator-admin-backend main-${GITHUB_SHA::8}

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   auto-git-tag:
     runs-on: ubuntu-latest
+
+    # Expose step outputs as job outputs
+    outputs:
+      new_tag: ${{ steps.run_git_auto_tag.outputs.new_tag }}
+
     steps:
     - uses: actions/github-script@v6
       id: get_pr_data
@@ -24,6 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: fregante/setup-git-user@v2
     - name: Run Auto-tagging
+      id: run_git_auto_tag
       # User controlled input needs to be santitised beforehand e.g., by adding an
       # intermediate env var to prevent the workflow being exposed to a critical
       # command injection attack
@@ -32,4 +38,5 @@ jobs:
         PR_NUMBER: '${{ fromJson(steps.get_pr_data.outputs.result).number }}'
       run: |
         echo "Attempting to auto-tag merge commit"
-        .github/auto-tag.sh "${PR_BODY}" "${PR_NUMBER}"
+        new_tag=$(.github/auto-tag.sh "${PR_BODY}" "${PR_NUMBER}")
+        echo "new_tag=${new_tag}"  >> "$GITHUB_OUTPUT"

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -1,9 +1,9 @@
 name: main push git autotag
 
 on:
-  push #:
-    # branches:
-    #   - main
+  push:
+    branches:
+      - main
 
 jobs:
   auto-git-tag:

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -65,6 +65,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          docker pull ${DOCKER_REGISTRY}/navigator-admin-backend:main-dceb7695
-          docker tag ${DOCKER_REGISTRY}/navigator-admin-backend:main-dceb7695  navigator-admin-backend:main-dceb7695
-          .github/retag-and-push.sh navigator-admin-backend main-dceb7695
+          .github/retag-and-push.sh navigator-admin-backend main-${GITHUB_SHA::8}

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -1,9 +1,9 @@
 name: main push git autotag
 
 on:
-  push:
-    branches:
-      - main
+  push #:
+    # branches:
+    #   - main
 
 jobs:
   auto-git-tag:

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -40,3 +40,29 @@ jobs:
         echo "Attempting to auto-tag merge commit"
         new_tag=$(.github/auto-tag.sh "${PR_BODY}" "${PR_NUMBER}")
         echo "new_tag=${new_tag}"  >> "$GITHUB_OUTPUT"
+
+  auto-semver-tag:
+    needs: auto-git-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1.6.1
+
+      - name: Docker pull, retag and push
+        env:
+          NEW_TAG: ${{needs.auto-git-tag.outputs.new_tag}}
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          .github/retag-and-push.sh navigator-admin-backend ${NEW_TAG}

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -66,4 +66,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           docker pull ${DOCKER_REGISTRY}/navigator-admin-backend:main-d62fb12f
+          docker tag ${DOCKER_REGISTRY}/navigator-admin-backend:main-d62fb12f  navigator-admin-backend:main-d62fb12f
           .github/retag-and-push.sh navigator-admin-backend main-d62fb12f

--- a/.github/workflows/main-push-git-autotag.yml
+++ b/.github/workflows/main-push-git-autotag.yml
@@ -65,6 +65,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          docker pull ${DOCKER_REGISTRY}/navigator-admin-backend:main-d62fb12f
-          docker tag ${DOCKER_REGISTRY}/navigator-admin-backend:main-d62fb12f  navigator-admin-backend:main-d62fb12f
-          .github/retag-and-push.sh navigator-admin-backend main-d62fb12f
+          docker pull ${DOCKER_REGISTRY}/navigator-admin-backend:main-dceb7695
+          docker tag ${DOCKER_REGISTRY}/navigator-admin-backend:main-dceb7695  navigator-admin-backend:main-dceb7695
+          .github/retag-and-push.sh navigator-admin-backend main-dceb7695

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - v*
 
+  workflow_run:
+    workflows: ["main push git autotag"]
+    types:
+      - completed
+
 env:
   DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -2,8 +2,7 @@ name: Semver Tagging
 
 on:
   push:
-    tags:
-      - v*
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
 
   workflow_run:
     workflows: ["main push git autotag"]

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -5,7 +5,7 @@ on:
     tags: ['v[0-9]+.[0-9]+.[0-9]+']
 
   workflow_run:
-    workflows: ["main push git autotag"]
+    workflows: ["CI"]
     types:
       - completed
 


### PR DESCRIPTION
# Description

- Fix auto semver tagging for auto generated git tags
- Triggered semver tagging for versions 1.0.7 and 1.0.9 that were missing due to the bug introduced because of the auto git tagging
- Driveby update to make semver job depend on the CI job to make sure semver tagging on main does not keep failing

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

1.0.7 and 1.0.9 now in ECR:
![image](https://github.com/climatepolicyradar/navigator-admin-backend/assets/46493669/c07bd20f-d5ac-4790-a93a-df3526f457c6)

![image](https://github.com/climatepolicyradar/navigator-admin-backend/assets/46493669/1cf5454d-b89c-4a02-8492-5736c6d95e8c)


## Reviewer Checklist

- [x] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
