### PR TITLE
Fix new_tag returning empty in ci

### DIFF
--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 script_folder=$(dirname "${BASH_SOURCE[0]}")
 source "${script_folder}"/funcs.sh

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 script_folder=$(dirname "${BASH_SOURCE[0]}")
 source "${script_folder}"/funcs.sh

--- a/.github/auto-tag.sh
+++ b/.github/auto-tag.sh
@@ -15,9 +15,9 @@ echo "Latest tag: ${latest_tag}"
 pr_body="$1"
 
 # Get selected versioning checkboxes.
-is_patch=$(set -e is_patch_selected "${pr_body}")
-is_minor=$(set -e is_minor_selected "${pr_body}")
-is_major=$(set -e is_major_selected "${pr_body}")
+is_patch=$(is_patch_selected "${pr_body}")
+is_minor=$(is_minor_selected "${pr_body}")
+is_major=$(is_major_selected "${pr_body}")
 
 pr_number="$2"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    tags: ['v*']
     branches:
       - main
   pull_request:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,9 +6,6 @@ on:
     types:
       - completed
 
-  push:
-    tags: ['v*']
-
 jobs:
   auto-git-and-semver-tag:
     runs-on: ubuntu-latest
@@ -81,7 +78,7 @@ jobs:
         git push --tags origin "${new_tag}"
 
   semver-for-manually-created-tags:
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   auto-git-and-semver-tag:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && github.event.workflow_run.conclusion == 'success' }}
 
     # Expose step outputs as job outputs
     outputs:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -44,7 +44,11 @@ jobs:
       run: |
         echo "Attempting to auto-tag merge commit"
         script_output=$(set -e; .github/auto-tag.sh "${PR_BODY}" "${PR_NUMBER}")
+        if $? != 0; then
+          exit 1
+        fi
         script_output=$(set -e; echo "${new_tag}" | tail -n 1)
+        echo "New tag version: ${script_output}"
         echo "new_tag=${script_output}"  >> "$GITHUB_OUTPUT"
 
     - name: Configure AWS credentials

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   auto-git-and-semver-tag:
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' && github.event.workflow_run.conclusion == 'success' }}
 
     # Expose step outputs as job outputs
     outputs:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   auto-git-and-semver-tag:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && github.event.workflow_run.conclusion == 'success' }}
 
     # Expose step outputs as job outputs
     outputs:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -80,7 +80,7 @@ jobs:
         git push --tags origin "${new_tag}"
 
   semver-for-manually-created-tags:
-    if: ${{ startsWith(github.ref, 'refs/tags/') && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   auto-git-and-semver-tag:
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' && github.event.workflow_run.conclusion == 'success' }}
 
     # Expose step outputs as job outputs
     outputs:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -40,11 +40,11 @@ jobs:
         PR_NUMBER: '${{ fromJson(steps.get_pr_data.outputs.result).number }}'
       run: |
         echo "Attempting to auto-tag merge commit"
-        script_output=$(set -e; .github/auto-tag.sh "${PR_BODY}" "${PR_NUMBER}")
+        script_output=$(.github/auto-tag.sh "${PR_BODY}" "${PR_NUMBER}")
         if $? != 0; then
           exit 1
         fi
-        script_output=$(set -e; echo "${new_tag}" | tail -n 1)
+        script_output=$(echo "${new_tag}" | tail -n 1)
         echo "New tag version: ${script_output}"
         echo "new_tag=${script_output}"  >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
# Description

- Removed debug set -x
- Removed set -e as it was suppressing auto-tag script output

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
