### PR TITLE
Pdct 820/adding a family document which we dont have a url for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,13 @@ migrations:
 	docker compose run --rm navigator-admin-backend python3 app/initial_data.py
 
 run: 
-	docker-compose -f docker-compose.yml up -d --remove-orphans
+	docker compose -f docker-compose.yml up -d --remove-orphans
 
-start: build run migrations
+start: build_dev run
+
+restart:
+	docker stop navigator-admin-backend && docker rm navigator-admin-backend && make start && docker logs -f navigator-admin-backend
+
 
 show_logs: 
-	- docker-compose logs -f
+	- docker compose logs -f

--- a/integration_tests/document/test_update.py
+++ b/integration_tests/document/test_update.py
@@ -1,16 +1,16 @@
 from typing import Tuple, cast
 
-from fastapi import status
-from fastapi.testclient import TestClient
-from pydantic import AnyHttpUrl
-from sqlalchemy.orm import Session
-
 from db_client.models.document.physical_document import (
     LanguageSource,
     PhysicalDocument,
     PhysicalDocumentLanguage,
 )
 from db_client.models.law_policy.family import FamilyDocument, Slug
+from fastapi import status
+from fastapi.testclient import TestClient
+from pydantic import AnyHttpUrl
+from sqlalchemy.orm import Session
+
 from app.model.document import DocumentWriteDTO
 from integration_tests.setup_db import EXPECTED_DOCUMENTS, setup_db
 from unit_tests.helpers.document import create_document_write_dto
@@ -308,3 +308,57 @@ def test_update_document_blank_variant(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     data = response.json()
     assert data["detail"] == "Variant name is empty"
+
+
+def test_update_document_idempotent_user_language(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    new_document = DocumentWriteDTO(
+        variant_name="Translation",
+        role="SUMMARY",
+        type="Annex",
+        title="Updated Title",
+        source_url=cast(AnyHttpUrl, "http://update_source"),
+        user_language_name=None,
+    )
+    print(new_document.model_dump(mode="json"))
+    response = client.put(
+        "/api/v1/documents/D.0.0.2",
+        json=new_document.model_dump(mode="json"),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["import_id"] == "D.0.0.2"
+    assert data["variant_name"] == "Translation"
+    assert data["role"] == "SUMMARY"
+    assert data["type"] == "Annex"
+    assert data["title"] == "Updated Title"
+    assert data["source_url"] == "http://update_source/"
+    assert data["slug"].startswith("updated-title")
+    assert data["user_language_name"] is None
+
+    fd, pd = _get_doc_tuple(test_db, "D.0.0.2")
+    assert fd.import_id == "D.0.0.2"
+    assert fd.variant_name == "Translation"
+    assert fd.document_role == "SUMMARY"
+    assert fd.document_type == "Annex"
+    assert pd.title == "Updated Title"
+    assert pd.source_url == "http://update_source/"
+
+    # Check the user language in the db
+    lang = (
+        test_db.query(PhysicalDocumentLanguage)
+        .filter(PhysicalDocumentLanguage.document_id == data["physical_id"])
+        .filter(PhysicalDocumentLanguage.source == LanguageSource.USER)
+        .one_or_none()
+    )
+    assert lang is None
+
+    # Check slug is updated too
+    slugs = (
+        test_db.query(Slug).filter(Slug.family_document_import_id == "D.0.0.2").all()
+    )
+    last_slug = slugs[-1].name
+    assert last_slug.startswith("updated-title")


### PR DESCRIPTION
# Description

- Update Makefile
- Only delete language if existing language is not None
- Added test for update doc with idempotent language

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Added new test to check updating document when language idempotent

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
