### PR TITLE
PDCT-954 fix the fields, str conversion and add new test

### DIFF
--- a/app/model/document.py
+++ b/app/model/document.py
@@ -26,7 +26,7 @@ class DocumentReadDTO(BaseModel):
     title: str
     md5_sum: Optional[str]
     cdn_object: Optional[str]
-    source_url: Optional[AnyHttpUrl]
+    source_url: Optional[AnyHttpUrl] = None
     content_type: Optional[str]
     user_language_name: Optional[str]
     calc_language_name: Optional[str]
@@ -40,7 +40,7 @@ class DocumentWriteDTO(BaseModel):
     role: Optional[str]
     type: Optional[str]
     title: str
-    source_url: Optional[AnyHttpUrl]
+    source_url: Optional[AnyHttpUrl] = None
     user_language_name: Optional[str]
 
 
@@ -55,7 +55,7 @@ class DocumentCreateDTO(BaseModel):
 
     # From PhysicalDocument
     title: str
-    source_url: Optional[AnyHttpUrl]
+    source_url: Optional[AnyHttpUrl] = None
     user_language_name: Optional[str]
 
 

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -249,7 +249,9 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
         .where(PhysicalDocument.id == original_pd.id)
         .values(
             title=new_values["title"],
-            source_url=str(new_values["source_url"]),
+            source_url=str(new_values["source_url"])
+            if new_values["source_url"] is not None
+            else None,
         ),
         db_update(FamilyDocument)
         .where(FamilyDocument.import_id == original_fd.import_id)

--- a/integration_tests/document/test_update.py
+++ b/integration_tests/document/test_update.py
@@ -87,6 +87,59 @@ def test_update_document(client: TestClient, test_db: Session, user_header_token
     assert last_slug.startswith("updated-title")
 
 
+def test_update_document_no_source_url(
+    client: TestClient, test_db: Session, user_header_token
+):
+    setup_db(test_db)
+    new_document = DocumentWriteDTO(
+        variant_name="Translation",
+        role="SUMMARY",
+        type="Annex",
+        title="Updated Title No Source URL",
+        source_url=None,
+        user_language_name="Ghotuo",
+    )
+    response = client.put(
+        "/api/v1/documents/D.0.0.2",
+        json=new_document.model_dump(mode="json"),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["import_id"] == "D.0.0.2"
+    assert data["variant_name"] == "Translation"
+    assert data["role"] == "SUMMARY"
+    assert data["type"] == "Annex"
+    assert data["title"] == new_document.title
+    assert data["source_url"] == new_document.source_url
+    assert data["slug"].startswith("updated-title")
+    assert data["user_language_name"] == "Ghotuo"
+
+    fd, pd = _get_doc_tuple(test_db, "D.0.0.2")
+    assert fd.import_id == "D.0.0.2"
+    assert fd.variant_name == "Translation"
+    assert fd.document_role == "SUMMARY"
+    assert fd.document_type == "Annex"
+    assert pd.title == new_document.title
+    assert pd.source_url == new_document.source_url
+
+    # Check the user language in the db
+    lang = (
+        test_db.query(PhysicalDocumentLanguage)
+        .filter(PhysicalDocumentLanguage.document_id == data["physical_id"])
+        .filter(PhysicalDocumentLanguage.source == LanguageSource.USER)
+        .one()
+    )
+    assert lang.language_id == 1
+
+    # Check slug is updated too
+    slugs = (
+        test_db.query(Slug).filter(Slug.family_document_import_id == "D.0.0.2").all()
+    )
+    last_slug = slugs[-1].name
+    assert last_slug.startswith("updated-title")
+
+
 def test_update_document_remove_variant(
     client: TestClient, test_db: Session, user_header_token
 ):


### PR DESCRIPTION
# Description

- Update source_url type field definition according to Pydantic v2.
- Update str conversion allowing None type (if apply) as create method currently.
- Add a new test for updating a Document without source_url property.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit and Integrity testing

## Reviewer Checklist

- [x] The PR represents a single feature (small drive-by fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
