### PR TITLE
Pdct 981/admin api if language idempotent language is removed from document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,17 @@ run:
 
 start: build_dev run
 
-restart:
-	docker stop navigator-admin-backend && docker rm navigator-admin-backend && make start && docker logs -f navigator-admin-backend
+start_local: build
+	# - docker stop navigator-admin-backend
+	docker run -p 8888:8888 \
+	--name navigator-admin-backend \
+	--network=navigator-backend_default \
+	-e ADMIN_POSTGRES_HOST=backend_db \
+	-e SECRET_KEY="secret_test_key" \
+	-d navigator-admin-backend
 
+restart: build
+	docker stop navigator-admin-backend && docker rm navigator-admin-backend && make start_local && docker logs -f navigator-admin-backend
 
 show_logs: 
 	- docker compose logs -f

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -230,7 +230,7 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
     # User Language changed?
     existing_language = _get_existing_language(db, original_fd)
     new_language = _get_requested_language(db, new_values)
-    lang_idempotent = _is_language_idempotent(existing_language, new_language)
+    has_language_changed = _is_language_equal(existing_language, new_language)
 
     update_slug = original_pd.title != new_values["title"]
 
@@ -255,7 +255,7 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
     ]
 
     # Update logic to only perform update if not idempotent.
-    if not lang_idempotent:
+    if not has_language_changed:
         if new_language is not None:
             if existing_language is not None:
                 command = (
@@ -330,10 +330,11 @@ def _get_requested_language(db: Session, new_values: dict) -> Optional[Language]
     return new_language
 
 
-def _is_language_idempotent(
+def _is_language_equal(
     existing_language: Optional[Language],
     requested_language: Optional[Language],
 ) -> bool:
+    """Check whether the language is idempotent."""
     if (existing_language == requested_language) is None:
         return True
 

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -228,15 +228,9 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
         return False
 
     # User Language changed?
-    existing_language = (
-        db.query(PhysicalDocumentLanguage)
-        .filter(
-            PhysicalDocumentLanguage.document_id == original_fd.physical_document_id
-        )
-        .filter(PhysicalDocumentLanguage.source == LanguageSource.USER)
-        .one_or_none()
-    )
-    new_language = _get_new_language(db, new_values, existing_language)
+    existing_language = _get_existing_language(db, original_fd)
+    new_language = _get_requested_language(db, new_values)
+    lang_idempotent = _is_language_idempotent(existing_language, new_language)
 
     update_slug = original_pd.title != new_values["title"]
 
@@ -245,9 +239,11 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
         .where(PhysicalDocument.id == original_pd.id)
         .values(
             title=new_values["title"],
-            source_url=str(new_values["source_url"])
-            if new_values["source_url"] is not None
-            else None,
+            source_url=(
+                str(new_values["source_url"])
+                if new_values["source_url"] is not None
+                else None
+            ),
         ),
         db_update(FamilyDocument)
         .where(FamilyDocument.import_id == original_fd.import_id)
@@ -258,32 +254,36 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
         ),
     ]
 
-    if new_language is not None:
-        if existing_language is not None:
-            command = (
-                db_update(PhysicalDocumentLanguage)
-                .where(
-                    and_(
-                        PhysicalDocumentLanguage.document_id
-                        == original_fd.physical_document_id,
-                        PhysicalDocumentLanguage.source == LanguageSource.USER,
+    # Update logic to only perform update if not idempotent.
+    if not lang_idempotent:
+        if new_language is not None:
+            if existing_language is not None:
+                command = (
+                    db_update(PhysicalDocumentLanguage)
+                    .where(
+                        and_(
+                            PhysicalDocumentLanguage.document_id
+                            == original_fd.physical_document_id,
+                            PhysicalDocumentLanguage.source == LanguageSource.USER,
+                        )
                     )
+                    .values(language_id=new_language.id)
                 )
-                .values(language_id=new_language.id)
-            )
-        else:
-            command = db_insert(PhysicalDocumentLanguage).values(
-                document_id=original_fd.physical_document_id,
-                language_id=new_language.id,
-                source=LanguageSource.USER,
-            )
-        commands.append(command)
-    else:
-        if existing_language is not None:
-            command = db_delete(PhysicalDocumentLanguage).where(
-                PhysicalDocumentLanguage.document_id == original_fd.physical_document_id
-            )
+            else:
+                command = db_insert(PhysicalDocumentLanguage).values(
+                    document_id=original_fd.physical_document_id,
+                    language_id=new_language.id,
+                    source=LanguageSource.USER,
+                )
             commands.append(command)
+
+        else:
+            if existing_language is not None:
+                command = db_delete(PhysicalDocumentLanguage).where(
+                    PhysicalDocumentLanguage.document_id
+                    == original_fd.physical_document_id
+                )
+                commands.append(command)
 
     for c in commands:
         result = db.execute(c)
@@ -303,24 +303,49 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
     return True
 
 
-def _get_new_language(
-    db: Session, new_values: dict, pdl: PhysicalDocumentLanguage
+def _get_existing_language(
+    db: Session, original_fd: FamilyDocument
 ) -> Optional[Language]:
+    existing_language = (
+        db.query(PhysicalDocumentLanguage)
+        .filter(
+            PhysicalDocumentLanguage.document_id == original_fd.physical_document_id
+        )
+        .filter(PhysicalDocumentLanguage.source == LanguageSource.USER)
+        .one_or_none()
+    )
+    return existing_language
+
+
+def _get_requested_language(db: Session, new_values: dict) -> Optional[Language]:
     requested_language = new_values["user_language_name"]
     if requested_language is None:
         return None
-    else:
-        new_language = (
-            db.query(Language)
-            .filter(Language.name == new_values["user_language_name"])
-            .one()
-        )
-        update_language = (
-            pdl.language_id != new_language.id if pdl is not None else True
-        )
 
-        if update_language:
-            return new_language
+    new_language = (
+        db.query(Language)
+        .filter(Language.name == new_values["user_language_name"])
+        .one()
+    )
+    return new_language
+
+
+def _is_language_idempotent(
+    existing_language: Optional[Language],
+    requested_language: Optional[Language],
+) -> bool:
+    if (existing_language == requested_language) is None:
+        return True
+
+    if requested_language is not None:
+        is_idempotent = bool(
+            existing_language.language_id == requested_language.id
+            if existing_language is not None
+            else False
+        )
+        return is_idempotent
+
+    return False
 
 
 def create(db: Session, document: DocumentCreateDTO) -> str:

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -230,7 +230,7 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
     # User Language changed?
     existing_language = _get_existing_language(db, original_fd)
     new_language = _get_requested_language(db, new_values)
-    has_language_changed = _is_language_equal(existing_language, new_language)
+    has_language_changed = not _is_language_equal(existing_language, new_language)
 
     update_slug = original_pd.title != new_values["title"]
 
@@ -255,7 +255,7 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
     ]
 
     # Update logic to only perform update if not idempotent.
-    if not has_language_changed:
+    if has_language_changed:
         if new_language is not None:
             if existing_language is not None:
                 command = (


### PR DESCRIPTION
# Description

When updating a document, the user language was being correctly passed to the API - but if the language was idempotent the API was setting the user language as None in the database. 

This PR fixes that bug 🐛 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Have updated update document tests to make sure we are only testing one thing edge case test, as the edge case was not being tested as we were always changing all of the fields in each test. I think we need to review the slug tests however, as I'm not confident that they're working as expected anymore ([ticket for doing](https://linear.app/climate-policy-radar/issue/PDCT-983/review-and-update-slug-tests-in-admin-service)).

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
