### PR TITLE
Fix auto tag build step skipped

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,7 +59,10 @@ jobs:
         run: make test
 
   build:
-    if: ${{ success() && ! startsWith(github.ref, 'refs/tags') }}
+    if: |
+      always() &&
+      (needs.code-quality.result == 'success' && needs.test.result == 'success') &&
+      ! startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs:
       - code-quality
@@ -107,7 +110,13 @@ jobs:
           fi
 
   manual-semver:
-    if: ${{ startsWith(github.ref, 'refs/tags') }}
+    if: |
+      always() &&
+      (needs.code-quality.result == 'success' && needs.test.result == 'success') &&
+      startsWith(github.ref, 'refs/tags')
+    needs:
+      - code-quality
+      - test
     uses: climatepolicyradar/reusable-workflows/.github/workflows/semver.yml@v3
     secrets: inherit
     with:

--- a/.trunk/configure-pyright-with-pyenv.sh
+++ b/.trunk/configure-pyright-with-pyenv.sh
@@ -7,15 +7,18 @@ venv_name=$(grep -m 1 venv pyproject.toml | tr -s ' ' | tr -d '"' | tr -d "'" | 
 # Check if pyrightconfig already exists.
 if [[ ! -f pyrightconfig.json ]]; then
 	# Check if pyenv-pyright plugin is installed
-	if ! command -v pyenv 1>/dev/null; then
+	if ! command -v pyenv &>/dev/null; then
 		echo "pyenv not installed. Please install pyenv..."
 		exit 1
 	fi
 
 	pyenv_root=$(pyenv root)
-	dir_exists=$(ls -A "${pyenv_root}"/plugins/pyenv-pyright)
-	if [[ -z ${dir_exists} ]]; then
-		git clone https://github.com/alefpereira/pyenv-pyright.git "${pyenv_root}"/plugins/pyenv-pyright
+	dir_path="${pyenv_root}"/plugins/pyenv-pyright
+	if [[ ! -d ${dir_path} ]]; then
+		# trunk-ignore(shellcheck/SC2312)
+		if [[ -n $(ls -A "${dir_path}") ]]; then
+			git clone https://github.com/alefpereira/pyenv-pyright.git "${dir_path}"
+		fi
 	fi
 
 	# Generate the pyrightconfig.json file.


### PR DESCRIPTION
# Description

- Fix auto tag build step skipped
- Add proper failsafe for existing non empty dir in .trunk/configure-pyright-with-pyenv.sh

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
