### PR TITLE
Feature/pdct 937 change the schema to remove unused link tables

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,9 @@ Please select the option(s) below that are most relevant:
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
+- [ ] GitHub workflow update
+- [ ] Documentation update
+- [ ] Remove legacy code
 
 ## How Has This Been Tested?
 

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -10,12 +10,11 @@ from db_client.models.dfce.family import (
     Family,
     FamilyCorpus,
     FamilyDocument,
-    FamilyOrganisation,
     FamilyStatus,
     Slug,
 )
 from db_client.models.dfce.geography import Geography
-from db_client.models.dfce.metadata import FamilyMetadata, MetadataOrganisation
+from db_client.models.dfce.metadata import FamilyMetadata
 from db_client.models.organisation.corpus import Corpus
 from db_client.models.organisation.counters import CountedEntity
 from db_client.models.organisation.users import Organisation
@@ -47,22 +46,6 @@ def _get_query(db: Session) -> Query:
         .join(FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id)
         .join(Corpus, Corpus.import_id == FamilyCorpus.corpus_import_id)
         .join(Organisation, Corpus.organisation_id == Organisation.id)
-    )
-
-
-def _family_org_from_dto(
-    dto: FamilyCreateDTO, geo_id: int, org_id: int
-) -> Tuple[Family, Organisation]:
-    return (
-        Family(
-            import_id="",
-            title=dto.title,
-            description=dto.summary,
-            geography_id=geo_id,
-            family_category=dto.category,
-        ),
-        # TODO: Remove use of FamilyOrganisation
-        FamilyOrganisation(family_import_id="", organisation_id=org_id),
     )
 
 
@@ -343,15 +326,15 @@ def create(db: Session, family: FamilyCreateDTO, geo_id: int, org_id: int) -> st
     :return bool: True if new Family was created otherwise False.
     """
     try:
-        new_family, new_fam_org = _family_org_from_dto(family, geo_id, org_id)
-        new_family.import_id = cast(
-            Column, generate_import_id(db, CountedEntity.Family, org_id)
+        import_id = cast(Column, generate_import_id(db, CountedEntity.Family, org_id))
+        new_family = Family(
+            import_id=import_id,
+            title=family.title,
+            description=family.summary,
+            geography_id=geo_id,
+            family_category=family.category,
         )
         db.add(new_family)
-
-        # Old schema (to be removed in PDCT-937).
-        new_fam_org.family_import_id = new_family.import_id
-        db.add(new_fam_org)
 
         # New schema.
         new_fam_corpus = db.query(Corpus).filter(Corpus.organisation_id == org_id).one()
@@ -380,16 +363,9 @@ def create(db: Session, family: FamilyCreateDTO, geo_id: int, org_id: int) -> st
     # TODO Validate that the metadata being added conforms to corpus type. PDCT-945
 
     # Add the metadata
-    # tax to be removed in PDCT-937.
-    tax = (
-        db.query(MetadataOrganisation)
-        .filter(MetadataOrganisation.organisation_id == org_id)  # TODO: Remove
-        .one()
-    )
     db.add(
         FamilyMetadata(
             family_import_id=new_family.import_id,
-            taxonomy_id=tax.taxonomy_id,  # TODO Remove as part PDCT-937
             value=family.metadata,
         )
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -141,17 +141,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.34.71"
+version = "1.34.76"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.34.71-py3-none-any.whl", hash = "sha256:7ce8c9a50af2f8a159a0dd86b40011d8dfdaba35005a118e51cd3ac72dc630f1"},
-    {file = "boto3-1.34.71.tar.gz", hash = "sha256:d786e7fbe3c4152866199786468a625dc77b9f27294cd7ad4f63cd2e0c927287"},
+    {file = "boto3-1.34.76-py3-none-any.whl", hash = "sha256:530a4cea3d40a6bd2f15a368ea395beef1ea6dff4491823bc48bd20c7d4da655"},
+    {file = "boto3-1.34.76.tar.gz", hash = "sha256:8c598382e8fb61cfa8f75056197e9b509eb52039ebc291af3b1096241ba2542c"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.71,<1.35.0"
+botocore = ">=1.34.76,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -160,13 +160,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.71"
+version = "1.34.76"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.71-py3-none-any.whl", hash = "sha256:3bc9e23aee73fe6f097823d61f79a8877790436038101a83fa96c7593e8109f8"},
-    {file = "botocore-1.34.71.tar.gz", hash = "sha256:c58f9ed71af2ea53d24146187130541222d7de8c27eb87d23f15457e7b83d88b"},
+    {file = "botocore-1.34.76-py3-none-any.whl", hash = "sha256:62e45e7374844ee39e86a96fe7f5e973eb5bf3469da028b4e3a8caba0909fb1f"},
+    {file = "botocore-1.34.76.tar.gz", hash = "sha256:68be44487a95132fccbc0b836fded4190dae30324f6bf822e1b6efd385ffdc83"},
 ]
 
 [package.dependencies]
@@ -182,26 +182,27 @@ crt = ["awscrt (==0.19.19)"]
 
 [[package]]
 name = "build"
-version = "1.1.1"
+version = "1.2.1"
 description = "A simple, correct Python build frontend"
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "build-1.1.1-py3-none-any.whl", hash = "sha256:8ed0851ee76e6e38adce47e4bee3b51c771d86c64cf578d0c2245567ee200e73"},
-    {file = "build-1.1.1.tar.gz", hash = "sha256:8eea65bb45b1aac2e734ba2cc8dad3a6d97d97901a395bd0ed3e7b46953d2a31"},
+    {file = "build-1.2.1-py3-none-any.whl", hash = "sha256:75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4"},
+    {file = "build-1.2.1.tar.gz", hash = "sha256:526263f4870c26f26c433545579475377b2b7588b6f1eac76a001e873ae3e19d"},
 ]
 
 [package.dependencies]
 colorama = {version = "*", markers = "os_name == \"nt\""}
 importlib-metadata = {version = ">=4.6", markers = "python_full_version < \"3.10.2\""}
-packaging = ">=19.0"
+packaging = ">=19.1"
 pyproject_hooks = "*"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 docs = ["furo (>=2023.08.17)", "sphinx (>=7.0,<8.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)", "sphinx-issues (>=3.0.0)"]
-test = ["filelock (>=3)", "pytest (>=6.2.4)", "pytest-cov (>=2.12)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "setuptools (>=56.0.0)", "setuptools (>=56.0.0)", "setuptools (>=67.8.0)", "wheel (>=0.36.0)"]
-typing = ["importlib-metadata (>=5.1)", "mypy (>=1.5.0,<1.6.0)", "tomli", "typing-extensions (>=3.7.4.3)"]
+test = ["build[uv,virtualenv]", "filelock (>=3)", "pytest (>=6.2.4)", "pytest-cov (>=2.12)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "setuptools (>=56.0.0)", "setuptools (>=56.0.0)", "setuptools (>=67.8.0)", "wheel (>=0.36.0)"]
+typing = ["build[uv]", "importlib-metadata (>=5.1)", "mypy (>=1.9.0,<1.10.0)", "tomli", "typing-extensions (>=3.7.4.3)"]
+uv = ["uv (>=0.1.18)"]
 virtualenv = ["virtualenv (>=20.0.35)"]
 
 [[package]]
@@ -517,7 +518,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "db-client"
-version = "2.0.3"
+version = "3.4.0"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.9"
@@ -537,8 +538,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.2.2"
-resolved_reference = "83d0fe4dcc7f89299e623e356cb843823df4e606"
+reference = "v3.4.0"
+resolved_reference = "82502bf4663c5650dd02962533dbd9328c155be7"
 
 [[package]]
 name = "dill"
@@ -1035,20 +1036,20 @@ colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "jaraco-classes"
-version = "3.3.1"
+version = "3.4.0"
 description = "Utility functions for Python class constructs"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jaraco.classes-3.3.1-py3-none-any.whl", hash = "sha256:86b534de565381f6b3c1c830d13f931d7be1a75f0081c57dff615578676e2206"},
-    {file = "jaraco.classes-3.3.1.tar.gz", hash = "sha256:cb28a5ebda8bc47d8c8015307d93163464f9f2b91ab4006e09ff0ce07e8bfb30"},
+    {file = "jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"},
+    {file = "jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"},
 ]
 
 [package.dependencies]
 more-itertools = "*"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
@@ -1712,13 +1713,13 @@ files = [
 
 [[package]]
 name = "pycparser"
-version = "2.21"
+version = "2.22"
 description = "C parser in Python"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.8"
 files = [
-    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
-    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
 
 [[package]]
@@ -2076,7 +2077,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2839,13 +2839,13 @@ files = [
 
 [[package]]
 name = "werkzeug"
-version = "3.0.1"
+version = "3.0.2"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "werkzeug-3.0.1-py3-none-any.whl", hash = "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10"},
-    {file = "werkzeug-3.0.1.tar.gz", hash = "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc"},
+    {file = "werkzeug-3.0.2-py3-none-any.whl", hash = "sha256:3aac3f5da756f93030740bc235d3e09449efcf65f2f55e3602e1d851b8f48795"},
+    {file = "werkzeug-3.0.2.tar.gz", hash = "sha256:e39b645a6ac92822588e7b39a692e7828724ceae0b0d702ef96701f90e70128d"},
 ]
 
 [package.dependencies]
@@ -3046,4 +3046,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "5e52ca0b1f8d0916d6c986f526261045fb8b184d5c2006a3ee70ed1653c9dca1"
+content-hash = "92e22adbccb82f449d427df856adf0581867f0a678f7f17afe058e900a505f21"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ boto3 = "^1.28.46"
 moto = "^4.2.2"
 types-sqlalchemy = "^1.4.53.38"
 urllib3 = "^1.26.17"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.2.2" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.4.0" }
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.2.0"
+version = "2.3.0"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/family/test_create.py
+++ b/tests/integration_tests/family/test_create.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from db_client.models.dfce.collection import CollectionFamily
-from db_client.models.dfce.family import Family, FamilyCorpus, FamilyOrganisation, Slug
+from db_client.models.dfce.family import Family, FamilyCorpus, Slug
 from db_client.models.dfce.metadata import FamilyMetadata
 from db_client.models.organisation.corpus import Corpus
 from fastapi import status
@@ -51,16 +51,6 @@ def test_create_family(client: TestClient, data_db: Session, user_header_token):
     assert len(db_collection) == 1
     assert db_collection[0].collection_import_id == "C.0.0.3"
 
-    # Old schema test.
-    org_id = (
-        data_db.query(FamilyOrganisation.organisation_id)  # To be removed
-        .filter(
-            FamilyOrganisation.family_import_id == expected_import_id
-        )  # To be removed
-        .scalar()
-    )
-    assert org_id is not None
-
     # New schema tests.
     fc = (
         data_db.query(FamilyCorpus)
@@ -69,7 +59,11 @@ def test_create_family(client: TestClient, data_db: Session, user_header_token):
     )
     assert len(fc) == 1
     assert fc[-1].corpus_import_id is not None
-    corpus = data_db.query(Corpus).filter(Corpus.organisation_id == org_id).one()
+    corpus = (
+        data_db.query(Corpus)
+        .filter(Corpus.organisation_id == fc[-1].corpus_import_id)
+        .one()
+    )
     assert fc[-1].corpus_import_id == corpus.import_id
 
 

--- a/tests/integration_tests/family/test_create.py
+++ b/tests/integration_tests/family/test_create.py
@@ -60,11 +60,9 @@ def test_create_family(client: TestClient, data_db: Session, user_header_token):
     assert len(fc) == 1
     assert fc[-1].corpus_import_id is not None
     corpus = (
-        data_db.query(Corpus)
-        .filter(Corpus.organisation_id == fc[-1].corpus_import_id)
-        .one()
+        data_db.query(Corpus).filter(Corpus.import_id == fc[-1].corpus_import_id).one()
     )
-    assert fc[-1].corpus_import_id == corpus.import_id
+    assert len(corpus) == 1
 
 
 def test_create_family_when_not_authorised(client: TestClient, data_db: Session):

--- a/tests/integration_tests/family/test_create.py
+++ b/tests/integration_tests/family/test_create.py
@@ -60,9 +60,11 @@ def test_create_family(client: TestClient, data_db: Session, user_header_token):
     assert len(fc) == 1
     assert fc[-1].corpus_import_id is not None
     corpus = (
-        data_db.query(Corpus).filter(Corpus.import_id == fc[-1].corpus_import_id).one()
+        data_db.query(Corpus)
+        .filter(Corpus.import_id == fc[-1].corpus_import_id)
+        .one_or_none()
     )
-    assert len(corpus) == 1
+    assert corpus is not None
 
 
 def test_create_family_when_not_authorised(client: TestClient, data_db: Session):

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -13,11 +13,7 @@ from db_client.models.dfce.family import (
     FamilyEvent,
     Slug,
 )
-from db_client.models.dfce.metadata import (
-    FamilyMetadata,
-    MetadataOrganisation,
-    MetadataTaxonomy,
-)
+from db_client.models.dfce.metadata import FamilyMetadata
 from db_client.models.document.physical_document import (
     LanguageSource,
     PhysicalDocument,
@@ -245,15 +241,6 @@ def _setup_organisation(test_db: Session) -> tuple[int, int]:
     # Now an organisation
     org = test_db.query(Organisation).filter(Organisation.name == "CCLW").one()
 
-    # Remove default taxonomy from CCLW - old schema
-    # TODO: Remove this deletion in Milestone 4
-    mo = (
-        test_db.query(MetadataOrganisation)  # remove
-        .filter(MetadataOrganisation.organisation_id == org.id)  # remove
-        .one()
-    )
-    test_db.delete(mo)
-
     another_org = Organisation(
         name="Another org",
         description="because we will have more than one org",
@@ -367,22 +354,6 @@ def _setup_family_data(
             "allowed_values": [],
         },
     }
-    dummy_tax = MetadataTaxonomy(
-        id=99, description="to go", valid_metadata=valid_metadata
-    )
-
-    test_db.add(dummy_tax)
-    test_db.flush()
-
-    # Old Schema modification (to be removed)
-    # MetadataOrganisation
-    mo = MetadataOrganisation(taxonomy_id=dummy_tax.id, organisation_id=default_org_id)
-    test_db.add(mo)
-    test_db.flush()
-
-    omo = MetadataOrganisation(taxonomy_id=dummy_tax.id, organisation_id=other_org_id)
-    test_db.add(omo)
-    # End of "to be removed"
 
     # New Schema modification
     # CorpusType
@@ -446,7 +417,6 @@ def _setup_family_data(
         test_db.add(
             FamilyMetadata(
                 family_import_id=data["import_id"],
-                taxonomy_id=dummy_tax.id,  # soon no longer needed
                 value=data["metadata"],
             )
         )


### PR DESCRIPTION
# Description

- Bump dbclient to 3.4.0
- Remove all references to MetadataTaxonomy, FamilyOrganisation & MetadataOrganisation

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Github workflow update
- [ ] Documentation update
- [x] Remove legacy code

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
