### PR TITLE
Feature/pdct 1045 use canceled and always for ci checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,6 +39,7 @@ Please select the option(s) below that are most relevant:
 - [ ] GitHub workflow update
 - [ ] Documentation update
 - [ ] Remove legacy code
+- [ ] Dependency update
 
 ## How Has This Been Tested?
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,7 +23,7 @@ jobs:
 
   code-quality:
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.check-auto-tagging-will-work.result == 'skipped' || needs.check-auto-tagging-will-work.result == 'success') &&
       ! startsWith(github.ref, 'refs/tags')
     needs:
@@ -37,7 +37,7 @@ jobs:
 
   test:
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.check-auto-tagging-will-work.result == 'skipped' || needs.check-auto-tagging-will-work.result == 'success') &&
       ! startsWith(github.ref, 'refs/tags')
     needs:
@@ -62,7 +62,7 @@ jobs:
 
   build:
     if: |
-      always() &&
+      ! cancelled() && always() &&
       (needs.code-quality.result == 'success' && needs.test.result == 'success') &&
       ! startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
           fi
 
   manual-semver:
-    if: ${{ always() && startsWith(github.ref, 'refs/tags') }}
+    if: ${{ ! cancelled() && always() && startsWith(github.ref, 'refs/tags') }}
     uses: climatepolicyradar/reusable-workflows/.github/workflows/semver.yml@v3
     secrets: inherit
     with:
@@ -120,7 +120,7 @@ jobs:
       semver-tag: main-${GITHUB_SHA::8}
 
   tag:
-    if: ${{ always() && (needs.build.result == 'success')}}
+    if: ${{ ! cancelled() && always() && (needs.build.result == 'success')}}
     needs: build
     permissions:
       contents: write
@@ -134,7 +134,7 @@ jobs:
       DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
 
   release:
-    if: ${{ always() && (needs.tag.result == 'success' && needs.tag.outputs.new_tag != 'Skip')}}
+    if: ${{ ! cancelled() && always() && (needs.tag.result == 'success' && needs.tag.outputs.new_tag != 'Skip')}}
     needs: tag
     permissions:
       contents: write

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,11 +1,25 @@
 # Autoformatter friendly markdownlint config (all formatting rules disabled)
 default: true
-blank_lines: false
-bullet: false
-html: false
-indentation: false
-line_length: false
-spaces: false
-url: false
-whitespace: false
-tables: false
+
+MD013:
+  # Number of characters
+  line_length: 80
+
+  # Number of characters for headings
+  heading_line_length: 80
+
+  # Number of characters for code blocks
+  code_block_line_length: 80
+
+  # Include code blocks
+  headings: true
+
+  # Don't include tables
+  tables: false
+  code_blocks: false
+
+  # Strict length checking
+  strict: false
+
+  # Stern length checking
+  stern: false


### PR DESCRIPTION
# Description

Use always() and ! cancelled() to avoid uncancellable workflows

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
