### PR TITLE
Bugfix/pdct 1019 fix family delete

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,6 +16,9 @@ permissions: read-all
 
 jobs:
   check-auto-tagging-will-work:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     if: |
       github.event_name == 'pull_request' &&
       (! startsWith(github.ref, 'refs/tags') && ! startsWith(github.ref, 'refs/heads/main'))

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -24,6 +24,10 @@ runtimes:
 # This is the section where you manage your linters.
 # (https://docs.trunk.io/check/configuration)
 lint:
+  disabled:
+    # Hadolint seems to have excessive memory use on Mac.
+    # Disable until we can investigate further.
+    - hadolint
   definitions:
     - name: bandit
       direct_configs: [bandit.yaml]
@@ -35,26 +39,33 @@ lint:
     - actionlint@1.6.27
     - bandit@1.7.8
     - black@24.3.0
-    - checkov@3.2.44
+    - checkov@3.2.55
     - git-diff-check
-    - hadolint@2.12.0
     - isort@5.13.2
     - markdownlint@0.39.0
     - osv-scanner@1.7.0
-    - pre-commit-hooks@4.5.0:
+    - pre-commit-hooks@4.6.0:
         commands:
-          - end-of-file-fixer
+          - check-ast
+          - check-case-conflict
+          - check-docstring-first
           - check-json
-          - detect-aws-credentials
+          - check-merge-conflict
+          - check-toml
+          - check-yaml
+          - debug-statements
+          - detect-aws-credentials --allow-missing-credentials
+          - end-of-file-fixer
+          - trailing-whitespace
     - prettier@3.2.5
-    - pyright@1.1.355
-    - ruff@0.3.4
+    - pyright@1.1.357
+    - ruff@0.3.5
     - shellcheck@0.10.0
     - shfmt@3.6.0
     - taplo@0.8.1
     - terrascan@1.19.1
-    - trivy@0.50.0
-    - trufflehog@3.70.3
+    - trivy@0.50.1
+    - trufflehog@3.71.0
     - yamllint@1.35.1
 
 actions:

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -202,7 +202,9 @@ def create(
 
 @db_session.with_transaction(__name__)
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-def delete(import_id: str, context=None, db: Session = db_session.get_db()) -> bool:
+def delete(
+    import_id: str, context=None, db: Session = db_session.get_db()
+) -> Optional[bool]:
     """
     Deletes the Family specified by the import_id.
 
@@ -214,6 +216,11 @@ def delete(import_id: str, context=None, db: Session = db_session.get_db()) -> b
     id.validate(import_id)
     if context is not None:
         context.error = f"Unable to delete family {import_id}"
+
+    # Get family we're going to delete.
+    family = get(import_id)
+    if family is None:
+        return None
 
     return family_repo.delete(db, import_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.3.0"
+version = "2.3.1"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit_tests/service/test_family_service.py
+++ b/tests/unit_tests/service/test_family_service.py
@@ -117,11 +117,11 @@ def test_delete(family_repo_mock):
     assert family_repo_mock.delete.call_count == 1
 
 
-def test_delete_missing(family_repo_mock):
+def test_delete_when_family_missing(family_repo_mock):
     family_repo_mock.return_empty = True
     ok = family_service.delete("a.b.c.d")
     assert not ok
-    assert family_repo_mock.delete.call_count == 1
+    assert family_repo_mock.delete.call_count == 0
 
 
 def test_delete_raises_when_invalid_id(family_repo_mock):


### PR DESCRIPTION
# Description

Enable hard delete of unpublished families with no documents
- https://linear.app/climate-policy-radar/issue/PDCT-1019/cant-delete-families-with-red-next-to-it
 
Allows us to fix issues caused by:
https://linear.app/climate-policy-radar/issue/PDCT-968/create-family-button-always-calls-api-even-if-data-missing-user-exits

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
