### PR TITLE
Filter on the document's organisation

### DIFF
--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -2,7 +2,13 @@ import logging
 from typing import Optional, Tuple, Union, cast
 
 from db_client.models.dfce import FamilyDocument
-from db_client.models.dfce.family import DocumentStatus, Slug
+from db_client.models.dfce.family import (
+    Corpus,
+    DocumentStatus,
+    Family,
+    FamilyCorpus,
+    Slug,
+)
 from db_client.models.document.physical_document import (
     Language,
     LanguageSource,
@@ -68,6 +74,10 @@ def _get_query(db: Session) -> Query:
         )
         .select_from(FamilyDocument, PhysicalDocument)
         .filter(FamilyDocument.physical_document_id == PhysicalDocument.id)
+        .join(Family, Family.import_id == FamilyDocument.family_import_id)
+        .join(FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id)
+        .join(Corpus, FamilyCorpus.corpus_import_id == FamilyCorpus.corpus_import_id)
+        .join(Organisation, Organisation.id == Corpus.organisation_id)
         .join(sq_slug, sq_slug.c.doc_id == FamilyDocument.import_id, isouter=True)
         .join(
             pdl_user,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.6.5"
+version = "2.6.6"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.6.4"
+version = "2.6.5"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/collection/test_search.py
+++ b/tests/integration_tests/collection/test_search.py
@@ -98,7 +98,7 @@ def test_search_collections_with_max_results(
     ids_found = set([f["import_id"] for f in data])
     assert len(ids_found) == 1
 
-    expected_ids = set(["C.0.0.2"])
+    expected_ids = set(["C.0.0.1"])
     assert ids_found.symmetric_difference(expected_ids) == set([])
 
 

--- a/tests/integration_tests/collection/test_search.py
+++ b/tests/integration_tests/collection/test_search.py
@@ -98,7 +98,7 @@ def test_search_collections_with_max_results(
     ids_found = set([f["import_id"] for f in data])
     assert len(ids_found) == 1
 
-    expected_ids = set(["C.0.0.1"])
+    expected_ids = set(["C.0.0.2"])
     assert ids_found.symmetric_difference(expected_ids) == set([])
 
 


### PR DESCRIPTION
# Description

Changes the query for a document to return its organisation, so a filter can be applied.

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
