### PR TITLE
Feature/pdct 1150 move familydocument query to use whole objects rather than

### DIFF
--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -178,7 +178,7 @@ def all(db: Session) -> list[DocumentReadDTO]:
     if not result:
         return []
 
-    return [DocumentReadDTO(**dict(r)) for r in result]
+    return [_doc_to_dto(doc) for doc in result]
 
 
 def get(db: Session, import_id: str) -> Optional[DocumentReadDTO]:
@@ -195,7 +195,7 @@ def get(db: Session, import_id: str) -> Optional[DocumentReadDTO]:
         _LOGGER.error(e)
         return
 
-    return DocumentReadDTO(**dict(result))
+    return _doc_to_dto(result)
 
 
 def search(
@@ -230,7 +230,7 @@ def search(
             raise TimeoutError
         raise RepositoryError(e)
 
-    return [DocumentReadDTO(**dict(r)) for r in result]
+    return [_doc_to_dto(doc) for doc in result]
 
 
 def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import Optional, Tuple, Union, cast
 
 from db_client.models.dfce import FamilyDocument
@@ -17,14 +18,13 @@ from db_client.models.document.physical_document import (
 )
 from db_client.models.organisation import Organisation
 from db_client.models.organisation.counters import CountedEntity
+from pydantic import AnyHttpUrl
 from sqlalchemy import Column, and_
 from sqlalchemy import delete as db_delete
-from sqlalchemy import func
 from sqlalchemy import insert as db_insert
 from sqlalchemy import update as db_update
 from sqlalchemy.exc import NoResultFound, OperationalError
 from sqlalchemy.orm import Query, Session, aliased
-from sqlalchemy.sql.functions import concat
 from sqlalchemy_utils import escape_like
 
 from app.errors import RepositoryError, ValidationError
@@ -35,50 +35,30 @@ from app.repository.helpers import generate_import_id, generate_slug
 _LOGGER = logging.getLogger(__name__)
 
 CreateObjects = Tuple[PhysicalDocumentLanguage, FamilyDocument, PhysicalDocument]
+ReadObj = Tuple[FamilyDocument, PhysicalDocument, Organisation, Language, Language]
 
 
 def _get_query(db: Session) -> Query:
+    # NOTE: SqlAlchemy will make a complete hash of the query generation
+    #       if columns are used in the query() call. Therefore, entire
+    #       objects are returned.
     lang_model = aliased(Language)
     lang_user = aliased(Language)
     pdl_model = aliased(PhysicalDocumentLanguage)
     pdl_user = aliased(PhysicalDocumentLanguage)
 
-    sq_slug = (
-        db.query(
-            func.string_agg(Slug.name, ",").label("name"),
-            Slug.family_document_import_id.label("doc_id"),
-        )
-        .group_by(Slug.family_document_import_id)
-        .subquery()
-    )
-
     return (
-        db.query(
-            FamilyDocument.import_id.label("import_id"),
-            FamilyDocument.family_import_id.label("family_import_id"),
-            FamilyDocument.variant_name.label("variant_name"),
-            FamilyDocument.document_status.label("status"),
-            FamilyDocument.document_role.label("role"),
-            FamilyDocument.document_type.label("type"),
-            FamilyDocument.created.label("created"),
-            FamilyDocument.last_modified.label("last_modified"),
-            concat(sq_slug.c.name).label("slug"),  # type: ignore
-            PhysicalDocument.id.label("physical_id"),
-            PhysicalDocument.title.label("title"),
-            PhysicalDocument.md5_sum.label("md5_sum"),
-            PhysicalDocument.cdn_object.label("cdn_object"),
-            PhysicalDocument.source_url.label("source_url"),
-            PhysicalDocument.content_type.label("content_type"),
-            lang_user.name.label("user_language_name"),
-            lang_model.name.label("calc_language_name"),
+        db.query(FamilyDocument, PhysicalDocument, Organisation, lang_user, lang_model)
+        .filter(FamilyDocument.family_import_id == Family.import_id)
+        .join(Family, FamilyDocument.family_import_id == Family.import_id)
+        .join(
+            PhysicalDocument,
+            FamilyDocument.physical_document_id == PhysicalDocument.id,
+            isouter=True,
         )
-        .select_from(FamilyDocument, PhysicalDocument)
-        .filter(FamilyDocument.physical_document_id == PhysicalDocument.id)
-        .join(Family, Family.import_id == FamilyDocument.family_import_id)
         .join(FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id)
-        .join(Corpus, FamilyCorpus.corpus_import_id == FamilyCorpus.corpus_import_id)
-        .join(Organisation, Organisation.id == Corpus.organisation_id)
-        .join(sq_slug, sq_slug.c.doc_id == FamilyDocument.import_id, isouter=True)
+        .join(Corpus, Corpus.import_id == FamilyCorpus.corpus_import_id)
+        .join(Organisation, Corpus.organisation_id == Organisation.id)
         .join(
             pdl_user,
             and_(
@@ -117,6 +97,53 @@ def _dto_to_family_document_dict(dto: DocumentCreateDTO) -> dict:
         "document_type": dto.type,
         "document_role": dto.role,
     }
+
+
+def _document_tuple_from_create_dto(
+    db: Session, dto: DocumentCreateDTO
+) -> CreateObjects:
+    language = PhysicalDocumentLanguage(
+        language_id=db.query(Language.id)
+        .filter(Language.name == dto.user_language_name)
+        .scalar(),
+        document_id=None,
+        source=LanguageSource.USER,
+        visible=True,
+    )
+    fam_doc = FamilyDocument(**_dto_to_family_document_dict(dto))
+    phys_doc = PhysicalDocument(
+        id=None,
+        title=dto.title,
+        # TODO: More verification needed here: PDCT-865
+        source_url=str(dto.source_url) if dto.source_url is not None else None,
+    )
+    return language, fam_doc, phys_doc
+
+
+def _doc_to_dto(doc_query_return: ReadObj) -> DocumentReadDTO:
+    fdoc, pdoc, org, lang_user, lang_model = doc_query_return
+
+    return DocumentReadDTO(
+        import_id=str(fdoc.import_id),
+        family_import_id=str(fdoc.family_import_id),
+        variant_name=str(fdoc.variant_name) if fdoc.variant_name is not None else None,
+        status=cast(DocumentStatus, fdoc.document_status),
+        role=str(fdoc.document_role) if fdoc.document_role is not None else None,
+        type=str(fdoc.document_type) if fdoc.document_type is not None else None,
+        created=cast(datetime, fdoc.created),
+        last_modified=cast(datetime, fdoc.last_modified),
+        slug=str(fdoc.slugs[-1].name if len(fdoc.slugs) > 0 else ""),
+        physical_id=cast(int, pdoc.id),
+        title=str(pdoc.title),
+        md5_sum=str(pdoc.md5_sum) if pdoc.md5_sum is not None else None,
+        cdn_object=str(pdoc.cdn_object) if pdoc.cdn_object is not None else None,
+        source_url=(
+            cast(AnyHttpUrl, pdoc.source_url) if pdoc.source_url is not None else None
+        ),
+        content_type=str(pdoc.content_type) if pdoc.content_type is not None else None,
+        user_language_name=str(lang_user.name) if lang_user is not None else None,
+        calc_language_name=str(lang_model.name) if lang_model is not None else None,
+    )
 
 
 def _document_tuple_from_dto(db: Session, dto: DocumentCreateDTO) -> CreateObjects:

--- a/tests/integration_tests/analytics/test_get.py
+++ b/tests/integration_tests/analytics/test_get.py
@@ -66,7 +66,7 @@ def test_get_analytics_summary_cclw(
 
     assert dict(sorted(data.items())) == {
         "n_collections": 2,
-        "n_documents": 2,
+        "n_documents": 0,
         "n_events": 3,
         "n_families": 2,
     }

--- a/tests/integration_tests/document/test_search.py
+++ b/tests/integration_tests/document/test_search.py
@@ -27,12 +27,12 @@ def test_search_document_super(
 
 
 def test_search_document_non_super(
-    client: TestClient, data_db: Session, user_header_token
+    client: TestClient, data_db: Session, non_cclw_user_header_token
 ):
     setup_db(data_db)
     response = client.get(
         "/api/v1/documents/?q=title",
-        headers=user_header_token,
+        headers=non_cclw_user_header_token,
     )
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
@@ -84,12 +84,12 @@ def test_search_document_when_db_error(
 
 
 def test_search_document_with_max_results(
-    client: TestClient, data_db: Session, user_header_token
+    client: TestClient, data_db: Session, non_cclw_user_header_token
 ):
     setup_db(data_db)
     response = client.get(
         "/api/v1/documents/?q=title&max_results=1",
-        headers=user_header_token,
+        headers=non_cclw_user_header_token,
     )
     assert response.status_code == status.HTTP_200_OK
     data = response.json()


### PR DESCRIPTION
# Description

FamilyDoc query bsae to use whole objects rather than columns - - unblocks ordering

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
