### PR TITLE
Feature/pdct 1068 user org not checked on document update

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -93,29 +93,15 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Publish initial image based on branch to ECR
+        id: retag_and_push_to_ecr
+        uses: climatepolicyradar/retag-and-push-to-ecr@v1
         env:
           DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF}" == "refs/heads"* ]]; then
-            branch="${GITHUB_REF/refs\/heads\//}"
-            if [[ "${branch}" = "main" ]]; then
-              docker_tag=latest
-              docker tag navigator-admin-backend "$ECR_REGISTRY/navigator-admin-backend:${docker_tag}"
-              docker push "$ECR_REGISTRY/navigator-admin-backend:${docker_tag}"
-            fi
-          elif [[ "${GITHUB_REF}" != "refs/tags"* ]]; then
-            echo "Assuming '${GITHUB_HEAD_REF}' is a branch"
-            if [[ -n "${GITHUB_HEAD_REF}" ]]; then
-                branch="$(echo ${GITHUB_HEAD_REF}| tr -c '[0-9,A-Z,a-z]' '-')"
-                timestamp=$(date --utc -Iseconds | cut -c1-19 | tr -c '[0-9]T\n' '-')
-                short_sha=${GITHUB_SHA:0:8}
-                docker_tag="${branch}-${timestamp}-${short_sha}"
-                docker tag navigator-admin-backend "$ECR_REGISTRY/navigator-admin-backend:${docker_tag}"
-                docker push "$ECR_REGISTRY/navigator-admin-backend:${docker_tag}"
-            fi
-          fi
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          repo-name: navigator-admin-backend
+          semver-tag: latest
 
   manual-semver:
     if: ${{ ! cancelled() && always() && startsWith(github.ref, 'refs/tags') }}

--- a/app/api/api_v1/routers/document.py
+++ b/app/api/api_v1/routers/document.py
@@ -22,9 +22,7 @@ _LOGGER = logging.getLogger(__name__)
     "/documents/{import_id}",
     response_model=DocumentReadDTO,
 )
-async def get_document(
-    import_id: str,
-) -> DocumentReadDTO:
+async def get_document(import_id: str) -> DocumentReadDTO:
     """
     Returns a specific document given the import id.
 
@@ -58,6 +56,7 @@ async def get_all_documents(request: Request) -> list[DocumentReadDTO]:
     """
     Returns all documents
 
+    :param Request request: Request object.
     :return DocumentDTO: returns a DocumentDTO of the document found.
     """
     try:
@@ -119,8 +118,7 @@ async def search_document(request: Request) -> list[DocumentReadDTO]:
     response_model=DocumentReadDTO,
 )
 async def update_document(
-    import_id: str,
-    new_document: DocumentWriteDTO,
+    import_id: str, new_document: DocumentWriteDTO
 ) -> DocumentReadDTO:
     """
     Updates a specific document given the import id.
@@ -145,10 +143,12 @@ async def update_document(
     return document
 
 
-@r.post("/documents", response_model=str, status_code=status.HTTP_201_CREATED)
-async def create_document(
-    new_document: DocumentCreateDTO,
-) -> str:
+@r.post(
+    "/documents",
+    response_model=str,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_document(new_document: DocumentCreateDTO) -> str:
     """
     Creates a specific document given the values in DocumentCreateDTO.
 
@@ -190,17 +190,16 @@ async def create_document(
 @r.delete(
     "/documents/{import_id}",
 )
-async def delete_document(
-    import_id: str,
-) -> None:
+async def delete_document(request: Request, import_id: str) -> None:
     """
     Deletes a specific document given the import id.
 
+    :param Request request: Request object.
     :param str import_id: Specified import_id.
     :raises HTTPException: If the document is not found a 404 is returned.
     """
     try:
-        document_deleted = document_service.delete(import_id)
+        document_deleted = document_service.delete(import_id, request.state.user.email)
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
     except RepositoryError as e:

--- a/app/api/api_v1/routers/document.py
+++ b/app/api/api_v1/routers/document.py
@@ -118,17 +118,22 @@ async def search_document(request: Request) -> list[DocumentReadDTO]:
     response_model=DocumentReadDTO,
 )
 async def update_document(
-    import_id: str, new_document: DocumentWriteDTO
+    request: Request, import_id: str, new_document: DocumentWriteDTO
 ) -> DocumentReadDTO:
     """
     Updates a specific document given the import id.
 
+    :param Request request: Request object.
     :param str import_id: Specified import_id.
     :raises HTTPException: If the document is not found a 404 is returned.
     :return DocumentDTO: returns a DocumentDTO of the document updated.
     """
     try:
-        document = document_service.update(import_id, new_document)
+        document = document_service.update(
+            import_id, new_document, request.state.user.email
+        )
+    except AuthorisationError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=e.message)
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
     except RepositoryError as e:

--- a/app/api/api_v1/routers/document.py
+++ b/app/api/api_v1/routers/document.py
@@ -212,5 +212,5 @@ async def delete_document(request: Request, import_id: str) -> None:
     if not document_deleted:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Document not deleted: {import_id}",
+            detail=f"Document {import_id} does not exist",
         )

--- a/app/api/api_v1/routers/document.py
+++ b/app/api/api_v1/routers/document.py
@@ -10,7 +10,7 @@ from app.api.api_v1.query_params import (
     set_default_query_params,
     validate_query_params,
 )
-from app.errors import RepositoryError, ValidationError
+from app.errors import AuthorisationError, RepositoryError, ValidationError
 from app.model.document import DocumentCreateDTO, DocumentReadDTO, DocumentWriteDTO
 
 document_router = r = APIRouter()
@@ -200,6 +200,8 @@ async def delete_document(request: Request, import_id: str) -> None:
     """
     try:
         document_deleted = document_service.delete(import_id, request.state.user.email)
+    except AuthorisationError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=e.message)
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
     except RepositoryError as e:

--- a/app/api/api_v1/routers/document.py
+++ b/app/api/api_v1/routers/document.py
@@ -148,15 +148,20 @@ async def update_document(
     response_model=str,
     status_code=status.HTTP_201_CREATED,
 )
-async def create_document(new_document: DocumentCreateDTO) -> str:
+async def create_document(request: Request, new_document: DocumentCreateDTO) -> str:
     """
     Creates a specific document given the values in DocumentCreateDTO.
 
+    :param Request request: Request object.
+    :param DocumentCreateDTO new_document: The new document data.
     :raises HTTPException: If the document is not found a 404 is returned.
     :return str: returns a the import_id of the document created.
     """
     try:
-        return document_service.create(new_document)
+        return document_service.create(new_document, request.state.user.email)
+    except AuthorisationError as e:
+        _LOGGER.error(e.message)
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=e.message)
     except ValidationError as e:
         _LOGGER.error(e.message)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)

--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -187,7 +187,7 @@ async def delete_family(request: Request, import_id: str) -> None:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message
         )
     except AuthorisationError as e:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=e.message)
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=e.message)
 
     if not family_deleted:
         raise HTTPException(

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -482,9 +482,17 @@ def count(db: Session, org_id: Optional[int]) -> Optional[int]:
     return n_documents
 
 
-def get_org_from_import_id(db: Session, import_id: str) -> Optional[int]:
-    result = _get_query(db).filter(FamilyDocument.import_id == import_id).one_or_none()
-    _LOGGER.error(result)
+def get_org_from_import_id(
+    db: Session, import_id: str, is_create: bool = False
+) -> Optional[int]:
+    query = _get_query(db)
+    if is_create:
+        query = query.filter(FamilyDocument.family_import_id == import_id).distinct(
+            FamilyDocument.family_import_id
+        )
+    else:
+        query = query.filter(FamilyDocument.import_id == import_id)
+    result = query.one_or_none()
     if result is None:
         return None
     _, _, org, _, _ = result

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -480,3 +480,12 @@ def count(db: Session, org_id: Optional[int]) -> Optional[int]:
         return
 
     return n_documents
+
+
+def get_org_from_import_id(db: Session, import_id: str) -> Optional[int]:
+    result = _get_query(db).filter(FamilyDocument.import_id == import_id).one_or_none()
+    _LOGGER.error(result)
+    if result is None:
+        return None
+    _, _, org, _, _ = result
+    return org.id

--- a/app/service/app_user.py
+++ b/app/service/app_user.py
@@ -5,7 +5,6 @@ from sqlalchemy.orm import Session
 
 from app.errors import AuthorisationError, ValidationError
 from app.repository import app_user_repo
-from app.service import organisation
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ def restrict_entities_to_user_org(db: Session, user_email: str) -> Optional[int]
 
 
 def is_authorised_to_make_changes(
-    db, user_email: str, org_name: str, entity: str, import_id: str
+    db, user_email: str, entity_org_id: int, import_id: str
 ) -> bool:
     """Validate entity belongs to same org as current user."""
 
@@ -42,9 +41,8 @@ def is_authorised_to_make_changes(
     if user_org_id is None:
         return True
 
-    entity_org_id = organisation.get_id_from_name(db, org_name)
     if entity_org_id != user_org_id:
-        msg = f"User '{user_email}' is not authorised to make changes to {entity} '{import_id}'"
+        msg = f"User '{user_email}' is not authorised to perform operation on '{import_id}'"
         raise AuthorisationError(msg)
 
     return bool(entity_org_id == user_org_id)

--- a/app/service/app_user.py
+++ b/app/service/app_user.py
@@ -26,9 +26,7 @@ def restrict_entities_to_user_org(db: Session, user_email: str) -> Optional[int]
     org_id = get_organisation(db, user_email)
     superuser: bool = is_superuser(db, user_email)
     if superuser:
-        _LOGGER.error("IS SUPERUSER")
         return None
-    _LOGGER.error("ORG ID: %s", org_id)
     return org_id
 
 

--- a/app/service/app_user.py
+++ b/app/service/app_user.py
@@ -42,7 +42,7 @@ def is_authorised_to_make_changes(
     if user_org_id is None:
         return True
 
-    entity_org_id = organisation.get_id(db, org_name)
+    entity_org_id = organisation.get_id_from_name(db, org_name)
     if entity_org_id != user_org_id:
         msg = f"User '{user_email}' is not authorised to make changes to {entity} '{import_id}'"
         raise AuthorisationError(msg)

--- a/app/service/collection.py
+++ b/app/service/collection.py
@@ -138,7 +138,7 @@ def update(
     """
 
     # TODO: implement changing of a collection's organisation
-    # org_id = organisation.get_id(db, collection.organisation)
+    # org_id = organisation.get_id_from_name(db, collection.organisation)
 
     validate_import_id(import_id)
     if context is not None:

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -146,7 +146,7 @@ def create(
     if family is None:
         raise ValidationError(f"Could not find family for {document.family_import_id}")
 
-    entity_org_id = get_org_from_id(db, family.import_id)
+    entity_org_id = get_org_from_id(db, family.import_id, is_create=True)
     app_user.is_authorised_to_make_changes(
         db, user_email, entity_org_id, family.import_id
     )
@@ -181,10 +181,10 @@ def delete(
     return document_repo.delete(db, import_id)
 
 
-def get_org_from_id(db: Session, import_id: str) -> int:
-    org = document_repo.get_org_from_import_id(db, import_id)
+def get_org_from_id(db: Session, import_id: str, is_create: bool = False) -> int:
+    org = document_repo.get_org_from_import_id(db, import_id, is_create)
     if org is None:
-        msg = f"The document import id {import_id} does not have an associated organisation"
+        msg = f"No organisation associated with import id {import_id}"
         _LOGGER.error(msg)
         raise ValidationError(msg)
     return org

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -150,7 +150,7 @@ def create(
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def delete(
     import_id: str, user_email: str, context=None, db: Session = db_session.get_db()
-) -> bool:
+) -> Optional[bool]:
     """
     Deletes the document specified by the import_id.
 
@@ -158,13 +158,13 @@ def delete(
     :param str user_email: The email address of the current user.
     :raises RepositoryError: raised on a database error.
     :raises ValidationError: raised should the import_id be invalid.
-    :return bool: True if deleted else False.
+    :return bool: True if deleted None if not.
     """
     id.validate(import_id)
 
     doc = get(import_id)
     if doc is None:
-        raise ValidationError(f"Could not find document {import_id}")
+        return None
 
     if context is not None:
         context.error = f"Could not delete document {import_id}"

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -119,7 +119,10 @@ def update(
 @db_session.with_transaction(__name__)
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def create(
-    document: DocumentCreateDTO, context=None, db: Session = db_session.get_db()
+    document: DocumentCreateDTO,
+    user_email: str,
+    context=None,
+    db: Session = db_session.get_db(),
 ) -> str:
     """
         Creates a new document with the values passed.
@@ -143,6 +146,10 @@ def create(
     if family is None:
         raise ValidationError(f"Could not find family for {document.family_import_id}")
 
+    entity_org_id = get_org_from_id(db, family.import_id)
+    app_user.is_authorised_to_make_changes(
+        db, user_email, entity_org_id, family.import_id
+    )
     return document_repo.create(db, document)
 
 
@@ -162,12 +169,12 @@ def delete(
     """
     id.validate(import_id)
 
+    if context is not None:
+        context.error = f"Could not delete document {import_id}"
+
     doc = get(import_id)
     if doc is None:
         return None
-
-    if context is not None:
-        context.error = f"Could not delete document {import_id}"
 
     entity_org_id = get_org_from_id(db, import_id)
     app_user.is_authorised_to_make_changes(db, user_email, entity_org_id, import_id)

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -112,6 +112,10 @@ def update(
     if context is not None:
         context.error = f"Error when updating document {import_id}"
 
+    doc = get(import_id)
+    if doc is None:
+        return None
+
     if document.variant_name == "":
         raise ValidationError("Variant name is empty")
 

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -179,5 +179,5 @@ def get_org_from_id(db: Session, import_id: str) -> int:
     if org is None:
         msg = f"The document import id {import_id} does not have an associated organisation"
         _LOGGER.error(msg)
-        raise RepositoryError(msg)
+        raise ValidationError(msg)
     return org

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -239,8 +239,9 @@ def delete(
         return None
 
     # Validate family belongs to same org as current user.
+    entity_org_id = organisation.get_id_from_name(db, family.organisation)
     authenticated = app_user.is_authorised_to_make_changes(
-        db, user_email, family.organisation, "family", import_id
+        db, user_email, entity_org_id, import_id
     )
     if authenticated:
         return family_repo.delete(db, import_id)

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -130,7 +130,7 @@ def update(
 
     # Validate family belongs to same org as current user.
     user_org_id = app_user.get_organisation(db, user_email)
-    org_id = organisation.get_id(db, family.organisation)
+    org_id = organisation.get_id_from_name(db, family.organisation)
     if org_id != user_org_id:
         msg = "Current user does not belong to the organisation that owns family "
         msg += import_id

--- a/app/service/organisation.py
+++ b/app/service/organisation.py
@@ -4,7 +4,7 @@ from app.errors import ValidationError
 from app.repository import organisation_repo
 
 
-def get_id(db: Session, org_name: str) -> int:
+def get_id_from_name(db: Session, org_name: str) -> int:
     id = organisation_repo.get_id_from_name(db, org_name)
     if id is None:
         raise ValidationError(f"The organisation name {org_name} is invalid!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.7.0"
+version = "2.8.0"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/document/test_delete.py
+++ b/tests/integration_tests/document/test_delete.py
@@ -19,6 +19,7 @@ def test_delete_document_super(
     assert data_db.query(FamilyDocument).count() == 3
     assert (
         data_db.query(FamilyDocument)
+        .filter(FamilyDocument.import_id == "D.0.0.2")
         .filter(FamilyDocument.document_status == DocumentStatus.DELETED)
         .count()
         == 1
@@ -33,6 +34,7 @@ def test_delete_document_cclw(client: TestClient, data_db: Session, user_header_
     assert data_db.query(FamilyDocument).count() == 3
     assert (
         data_db.query(FamilyDocument)
+        .filter(FamilyDocument.import_id == "D.0.0.3")
         .filter(FamilyDocument.document_status == DocumentStatus.DELETED)
         .count()
         == 1
@@ -51,6 +53,7 @@ def test_delete_document_unfccc(
     assert data_db.query(FamilyDocument).count() == 3
     assert (
         data_db.query(FamilyDocument)
+        .filter(FamilyDocument.import_id == "D.0.0.2")
         .filter(FamilyDocument.document_status == DocumentStatus.DELETED)
         .count()
         == 1

--- a/tests/integration_tests/document/test_delete.py
+++ b/tests/integration_tests/document/test_delete.py
@@ -8,10 +8,44 @@ from sqlalchemy.orm import Session
 from tests.integration_tests.setup_db import setup_db
 
 
-def test_delete_document(client: TestClient, data_db: Session, admin_user_header_token):
+def test_delete_document_super(
+    client: TestClient, data_db: Session, superuser_header_token
+):
     setup_db(data_db)
     response = client.delete(
-        "/api/v1/documents/D.0.0.2", headers=admin_user_header_token
+        "/api/v1/documents/D.0.0.2", headers=superuser_header_token
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert data_db.query(FamilyDocument).count() == 3
+    assert (
+        data_db.query(FamilyDocument)
+        .filter(FamilyDocument.document_status == DocumentStatus.DELETED)
+        .count()
+        == 1
+    )
+    assert data_db.query(PhysicalDocument).count() == 3
+
+
+def test_delete_document_cclw(client: TestClient, data_db: Session, user_header_token):
+    setup_db(data_db)
+    response = client.delete("/api/v1/documents/D.0.0.3", headers=user_header_token)
+    assert response.status_code == status.HTTP_200_OK
+    assert data_db.query(FamilyDocument).count() == 3
+    assert (
+        data_db.query(FamilyDocument)
+        .filter(FamilyDocument.document_status == DocumentStatus.DELETED)
+        .count()
+        == 1
+    )
+    assert data_db.query(PhysicalDocument).count() == 3
+
+
+def test_delete_document_unfccc(
+    client: TestClient, data_db: Session, non_cclw_user_header_token
+):
+    setup_db(data_db)
+    response = client.delete(
+        "/api/v1/documents/D.0.0.2", headers=non_cclw_user_header_token
     )
     assert response.status_code == status.HTTP_200_OK
     assert data_db.query(FamilyDocument).count() == 3
@@ -44,12 +78,10 @@ def test_delete_document_rollback(
     client: TestClient,
     data_db: Session,
     rollback_document_repo,
-    admin_user_header_token,
+    user_header_token,
 ):
     setup_db(data_db)
-    response = client.delete(
-        "/api/v1/documents/D.0.0.2", headers=admin_user_header_token
-    )
+    response = client.delete("/api/v1/documents/D.0.0.3", headers=user_header_token)
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert data_db.query(FamilyDocument).count() == 3
     assert (
@@ -63,15 +95,13 @@ def test_delete_document_rollback(
 
 
 def test_delete_document_when_not_found(
-    client: TestClient, data_db: Session, admin_user_header_token
+    client: TestClient, data_db: Session, user_header_token
 ):
     setup_db(data_db)
-    response = client.delete(
-        "/api/v1/documents/D.0.0.22", headers=admin_user_header_token
-    )
+    response = client.delete("/api/v1/documents/D.0.0.22", headers=user_header_token)
     assert response.status_code == status.HTTP_404_NOT_FOUND
     data = response.json()
-    assert data["detail"] == "Document not deleted: D.0.0.22"
+    assert data["detail"] == "Document D.0.0.22 does not exist"
     assert data_db.query(FamilyDocument).count() == 3
     assert (
         data_db.query(FamilyDocument)
@@ -83,13 +113,26 @@ def test_delete_document_when_not_found(
 
 
 def test_delete_document_when_db_error(
-    client: TestClient, data_db: Session, bad_document_repo, admin_user_header_token
+    client: TestClient, data_db: Session, bad_document_repo, user_header_token
 ):
     setup_db(data_db)
-    response = client.delete(
-        "/api/v1/documents/D.0.0.1", headers=admin_user_header_token
-    )
+    response = client.delete("/api/v1/documents/D.0.0.1", headers=user_header_token)
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     data = response.json()
     assert data["detail"] == "Bad Repo"
-    assert bad_document_repo.delete.call_count == 1
+
+
+def test_delete_document_when_org_mismatch(
+    client: TestClient, data_db: Session, user_header_token
+):
+    setup_db(data_db)
+    response = client.delete("/api/v1/documents/D.0.0.2", headers=user_header_token)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert data_db.query(FamilyDocument).count() == 3
+    assert (
+        data_db.query(FamilyDocument)
+        .filter(FamilyDocument.document_status == DocumentStatus.DELETED)
+        .count()
+        == 0
+    )
+    assert data_db.query(PhysicalDocument).count() == 3

--- a/tests/integration_tests/family/test_delete.py
+++ b/tests/integration_tests/family/test_delete.py
@@ -139,9 +139,9 @@ def test_delete_family_when_org_mismatch(
     response = client.delete(
         "/api/v1/families/A.0.0.1", headers=non_cclw_user_header_token
     )
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     data = response.json()
     assert (
         data["detail"]
-        == "User 'unfccc@cpr.org' is not authorised to make changes to family 'A.0.0.1'"
+        == "User 'unfccc@cpr.org' is not authorised to perform operation on 'A.0.0.1'"
     )

--- a/tests/mocks/repos/document_repo.py
+++ b/tests/mocks/repos/document_repo.py
@@ -70,7 +70,9 @@ def mock_document_repo(document_repo, monkeypatch: MonkeyPatch, mocker):
             return 11
         return
 
-    def mock_get_org_from_import_id(_, import_id: str) -> Optional[int]:
+    def mock_get_org_from_import_id(
+        _, import_id: str, is_create: bool
+    ) -> Optional[int]:
         maybe_throw()
         if document_repo.no_org is True:
             return None

--- a/tests/mocks/services/document_service.py
+++ b/tests/mocks/services/document_service.py
@@ -40,14 +40,17 @@ def mock_document_service(document_service, monkeypatch: MonkeyPatch, mocker):
         return [create_document_read_dto("search1")]
 
     def mock_update_document(
-        import_id: str, data: DocumentWriteDTO
+        import_id: str, data: DocumentWriteDTO, user_email: str
     ) -> Optional[DocumentReadDTO]:
         maybe_throw()
+        if document_service.org_mismatch:
+            raise AuthorisationError("Org mismatch")
+
         if document_service.missing:
             return
 
         if document_service.throw_validation_error:
-            raise ValidationError("Variant name is empty")
+            raise ValidationError("Validation error")
 
         return create_document_read_dto(import_id, "family_import_id", data.title)
 

--- a/tests/mocks/services/document_service.py
+++ b/tests/mocks/services/document_service.py
@@ -59,7 +59,7 @@ def mock_document_service(document_service, monkeypatch: MonkeyPatch, mocker):
             raise ValidationError(f"Could not find family for {data.family_import_id}")
         return "new.doc.id.0"
 
-    def mock_delete_document(_) -> bool:
+    def mock_delete_document(_, user_email: str) -> bool:
         maybe_throw()
         return not document_service.missing
 

--- a/tests/mocks/services/document_service.py
+++ b/tests/mocks/services/document_service.py
@@ -51,10 +51,13 @@ def mock_document_service(document_service, monkeypatch: MonkeyPatch, mocker):
 
         return create_document_read_dto(import_id, "family_import_id", data.title)
 
-    def mock_create_document(data: DocumentCreateDTO) -> str:
+    def mock_create_document(data: DocumentCreateDTO, user_email: str) -> str:
         maybe_throw()
+        if document_service.org_mismatch:
+            raise AuthorisationError("Org mismatch")
+
         if document_service.throw_validation_error:
-            raise ValidationError("Variant name is empty")
+            raise ValidationError("Validation error")
 
         if document_service.missing:
             raise ValidationError(f"Could not find family for {data.family_import_id}")

--- a/tests/unit_tests/routers/document/test_create_document.py
+++ b/tests/unit_tests/routers/document/test_create_document.py
@@ -29,3 +29,31 @@ def test_create_when_family_not_found(
     data = response.json()
     assert data["detail"] == "Could not find family for this_family"
     assert document_service_mock.create.call_count == 1
+
+
+def test_create_fails_when_validation_error(
+    client: TestClient, document_service_mock, user_header_token
+):
+    document_service_mock.throw_validation_error = True
+    new_data = create_document_create_dto("validation_error").model_dump(mode="json")
+    response = client.post(
+        "/api/v1/documents", json=new_data, headers=user_header_token
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    data = response.json()
+    assert data["detail"] == "Validation error"
+    assert document_service_mock.delete.call_count == 0
+
+
+def test_create_fails_when_org_mismatch(
+    client: TestClient, document_service_mock, user_header_token
+):
+    document_service_mock.org_mismatch = True
+    new_data = create_document_create_dto("unfccc_fam").model_dump(mode="json")
+    response = client.post(
+        "/api/v1/documents", json=new_data, headers=user_header_token
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    data = response.json()
+    assert data["detail"] == "Org mismatch"
+    assert document_service_mock.delete.call_count == 0

--- a/tests/unit_tests/routers/document/test_delete_document.py
+++ b/tests/unit_tests/routers/document/test_delete_document.py
@@ -15,7 +15,7 @@ def test_delete_when_not_found(
     response = client.delete("/api/v1/documents/doc1", headers=user_header_token)
     assert response.status_code == status.HTTP_404_NOT_FOUND
     data = response.json()
-    assert data["detail"] == "Document not deleted: doc1"
+    assert data["detail"] == "Document doc1 does not exist"
     assert document_service_mock.delete.call_count == 1
 
 

--- a/tests/unit_tests/routers/document/test_delete_document.py
+++ b/tests/unit_tests/routers/document/test_delete_document.py
@@ -1,31 +1,41 @@
-import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
 
-def test_delete_when_ok(
-    client: TestClient, document_service_mock, admin_user_header_token
-):
-    response = client.delete("/api/v1/documents/doc1", headers=admin_user_header_token)
+def test_delete_when_ok(client: TestClient, document_service_mock, user_header_token):
+    response = client.delete("/api/v1/documents/doc1", headers=user_header_token)
     assert response.status_code == status.HTTP_200_OK
     assert document_service_mock.delete.call_count == 1
 
 
-@pytest.mark.skip(reason="No admin user for MVP")
-def test_delete_document_fails_if_not_admin(
+def test_delete_when_not_found(
     client: TestClient, document_service_mock, user_header_token
 ):
-    response = client.delete("/api/v1/documents/doc1", headers=user_header_token)
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-    assert document_service_mock.delete.call_count == 0
-
-
-def test_delete_when_not_found(
-    client: TestClient, document_service_mock, admin_user_header_token
-):
     document_service_mock.missing = True
-    response = client.delete("/api/v1/documents/doc1", headers=admin_user_header_token)
+    response = client.delete("/api/v1/documents/doc1", headers=user_header_token)
     assert response.status_code == status.HTTP_404_NOT_FOUND
     data = response.json()
     assert data["detail"] == "Document not deleted: doc1"
+    assert document_service_mock.delete.call_count == 1
+
+
+def test_delete_fails_when_invalid_org(
+    client: TestClient, document_service_mock, user_header_token
+):
+    document_service_mock.throw_validation_error = True
+    response = client.delete("/api/v1/documents/doc1", headers=user_header_token)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    data = response.json()
+    assert data["detail"] == "No org"
+    assert document_service_mock.delete.call_count == 1
+
+
+def test_delete_fails_when_org_mismatch(
+    client: TestClient, document_service_mock, user_header_token
+):
+    document_service_mock.org_mismatch = True
+    response = client.delete("/api/v1/documents/doc1", headers=user_header_token)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    data = response.json()
+    assert data["detail"] == "Org mismatch"
     assert document_service_mock.delete.call_count == 1

--- a/tests/unit_tests/routers/document/test_search_document.py
+++ b/tests/unit_tests/routers/document/test_search_document.py
@@ -56,7 +56,8 @@ def test_search_when_not_found(
     with caplog.at_level(logging.INFO):
         response = client.get("/api/v1/documents/?q=stuff", headers=user_header_token)
     assert response.status_code == status.HTTP_200_OK
-    response.json()
+    result = response.json()
+    assert result == []
     assert document_service_mock.search.call_count == 1
     assert (
         "Documents not found for terms: {'q': 'stuff', 'max_results': 500}"

--- a/tests/unit_tests/routers/document/test_update_document.py
+++ b/tests/unit_tests/routers/document/test_update_document.py
@@ -39,5 +39,5 @@ def test_update_when_validation_error(
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     data = response.json()
-    assert data["detail"] == "Variant name is empty"
+    assert data["detail"] == "Validation error"
     assert document_service_mock.update.call_count == 1

--- a/tests/unit_tests/routers/family/test_delete_family.py
+++ b/tests/unit_tests/routers/family/test_delete_family.py
@@ -9,10 +9,8 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 
-def test_delete_when_ok(
-    client: TestClient, family_service_mock, admin_user_header_token
-):
-    response = client.delete("/api/v1/families/fam1", headers=admin_user_header_token)
+def test_delete_when_ok(client: TestClient, family_service_mock, user_header_token):
+    response = client.delete("/api/v1/families/fam1", headers=user_header_token)
     assert response.status_code == status.HTTP_200_OK
     assert family_service_mock.delete.call_count == 1
 
@@ -27,10 +25,10 @@ def test_delete_fails_when_not_admin(
 
 
 def test_delete_when_not_found(
-    client: TestClient, family_service_mock, admin_user_header_token
+    client: TestClient, family_service_mock, user_header_token
 ):
     family_service_mock.missing = True
-    response = client.delete("/api/v1/families/fam1", headers=admin_user_header_token)
+    response = client.delete("/api/v1/families/fam1", headers=user_header_token)
     assert response.status_code == status.HTTP_404_NOT_FOUND
     data = response.json()
     assert data["detail"] == "Family not deleted: fam1"
@@ -51,5 +49,5 @@ def test_delete_fails_when_org_mismatch(
 ):
     family_service_mock.org_mismatch = True
     response = client.delete("/api/v1/families/fam1", headers=user_header_token)
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.status_code == status.HTTP_403_FORBIDDEN
     assert family_service_mock.delete.call_count == 1

--- a/tests/unit_tests/service/document/test_create_document_service.py
+++ b/tests/unit_tests/service/document/test_create_document_service.py
@@ -75,7 +75,7 @@ def test_create_when_no_org_associated_with_entity(
         ok = doc_service.create(new_document, USER_EMAIL)
         assert not ok
 
-    expected_msg = "The document import id test.family.1.0 does not have an associated organisation"
+    expected_msg = "No organisation associated with import id test.family.1.0"
     assert e.value.message == expected_msg
 
     assert family_repo_mock.get.call_count == 1

--- a/tests/unit_tests/service/document/test_create_document_service.py
+++ b/tests/unit_tests/service/document/test_create_document_service.py
@@ -1,43 +1,104 @@
 import pytest
 
 import app.service.document as doc_service
-from app.errors import RepositoryError, ValidationError
+from app.errors import AuthorisationError, RepositoryError, ValidationError
 from tests.helpers.document import create_document_create_dto
 
-# --- CREATE
+USER_EMAIL = "test@cpr.org"
 
 
-def test_create(document_repo_mock, family_repo_mock):
+def test_create(document_repo_mock, family_repo_mock, app_user_repo_mock):
     new_document = create_document_create_dto()
-    document = doc_service.create(new_document)
+    document = doc_service.create(new_document, USER_EMAIL)
     assert document is not None
-    assert document_repo_mock.create.call_count == 1
+
     assert family_repo_mock.get.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 1
+    assert app_user_repo_mock.is_superuser.call_count == 1
+    assert document_repo_mock.create.call_count == 1
 
 
-def test_create_when_db_fails(document_repo_mock, family_repo_mock):
+def test_create_when_db_fails(document_repo_mock, family_repo_mock, app_user_repo_mock):
     new_document = create_document_create_dto()
     document_repo_mock.return_empty = True
 
     with pytest.raises(RepositoryError):
-        doc_service.create(new_document)
-    assert document_repo_mock.create.call_count == 1
+        doc_service.create(new_document, USER_EMAIL)
+
     assert family_repo_mock.get.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 1
+    assert app_user_repo_mock.is_superuser.call_count == 1
+    assert document_repo_mock.create.call_count == 1
 
 
-def test_create_raises_when_invalid_family_id(document_repo_mock):
+def test_create_raises_when_invalid_family_id(
+    document_repo_mock, family_repo_mock, app_user_repo_mock
+):
     new_document = create_document_create_dto(family_import_id="invalid family")
     with pytest.raises(ValidationError) as e:
-        doc_service.create(new_document)
+        doc_service.create(new_document, USER_EMAIL)
+
     expected_msg = f"The import id {new_document.family_import_id} is invalid!"
     assert e.value.message == expected_msg
+
+    assert family_repo_mock.get.call_count == 0
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
     assert document_repo_mock.create.call_count == 0
 
 
-def test_create_raises_when_blank_variant(document_repo_mock):
+def test_create_raises_when_blank_variant(
+    document_repo_mock, family_repo_mock, app_user_repo_mock
+):
     new_document = create_document_create_dto(variant_name="")
     with pytest.raises(ValidationError) as e:
-        doc_service.create(new_document)
+        doc_service.create(new_document, USER_EMAIL)
     expected_msg = "Variant name is empty"
     assert e.value.message == expected_msg
+
+    assert family_repo_mock.get.call_count == 0
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
+    assert document_repo_mock.create.call_count == 0
+
+
+def test_create_when_no_org_associated_with_entity(
+    document_repo_mock, family_repo_mock, app_user_repo_mock
+):
+    new_document = create_document_create_dto()
+    document_repo_mock.no_org = True
+    with pytest.raises(ValidationError) as e:
+        ok = doc_service.create(new_document, USER_EMAIL)
+        assert not ok
+
+    expected_msg = "The document import id test.family.1.0 does not have an associated organisation"
+    assert e.value.message == expected_msg
+
+    assert family_repo_mock.get.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
+    assert document_repo_mock.create.call_count == 0
+
+
+def test_create_when_org_mismatch(
+    document_repo_mock, family_repo_mock, app_user_repo_mock
+):
+    new_document = create_document_create_dto()
+    document_repo_mock.alternative_org = True
+    with pytest.raises(AuthorisationError) as e:
+        ok = doc_service.create(new_document, USER_EMAIL)
+        assert not ok
+
+    expected_msg = "User 'test@cpr.org' is not authorised to perform operation on 'test.family.1.0'"
+    assert e.value.message == expected_msg
+
+    assert family_repo_mock.get.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 1
+    assert app_user_repo_mock.is_superuser.call_count == 1
     assert document_repo_mock.create.call_count == 0

--- a/tests/unit_tests/service/document/test_delete_document_service.py
+++ b/tests/unit_tests/service/document/test_delete_document_service.py
@@ -49,9 +49,7 @@ def test_delete_when_no_org_associated_with_entity(
         ok = doc_service.delete("a.b.c.d", USER_EMAIL)
         assert not ok
 
-    expected_msg = (
-        "The document import id a.b.c.d does not have an associated organisation"
-    )
+    expected_msg = "No organisation associated with import id a.b.c.d"
     assert e.value.message == expected_msg
 
     assert document_repo_mock.get.call_count == 1

--- a/tests/unit_tests/service/document/test_delete_document_service.py
+++ b/tests/unit_tests/service/document/test_delete_document_service.py
@@ -1,28 +1,81 @@
 import pytest
 
 import app.service.document as doc_service
-from app.errors import ValidationError
+from app.errors import AuthorisationError, RepositoryError, ValidationError
 
-# --- DELETE
+USER_EMAIL = "test@cpr.org"
 
 
-def test_delete(document_repo_mock):
-    ok = doc_service.delete("a.b.c.d")
+def test_delete(document_repo_mock, app_user_repo_mock):
+    ok = doc_service.delete("a.b.c.d", USER_EMAIL)
     assert ok
+    assert document_repo_mock.get.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 1
+    assert app_user_repo_mock.is_superuser.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
     assert document_repo_mock.delete.call_count == 1
 
 
-def test_delete_when_missing(document_repo_mock):
-    document_repo_mock.return_empty = True
-    ok = doc_service.delete("a.b.c.d")
-    assert not ok
-    assert document_repo_mock.delete.call_count == 1
-
-
-def test_delete_raises_when_invalid_id(document_repo_mock):
+def test_delete_raises_when_invalid_id(document_repo_mock, app_user_repo_mock):
     import_id = "invalid"
     with pytest.raises(ValidationError) as e:
-        doc_service.delete(import_id)
+        doc_service.delete(import_id, USER_EMAIL)
     expected_msg = f"The import id {import_id} is invalid!"
     assert e.value.message == expected_msg
+    assert document_repo_mock.get.call_count == 0
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
+    assert document_repo_mock.delete.call_count == 0
+
+
+def test_delete_when_missing(document_repo_mock, app_user_repo_mock):
+    document_repo_mock.return_empty = True
+    with pytest.raises(ValidationError) as e:
+        ok = doc_service.delete("a.b.c.d", USER_EMAIL)
+        assert not ok
+
+    expected_msg = "Could not find document a.b.c.d"
+    assert e.value.message == expected_msg
+
+    assert document_repo_mock.get.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
+    assert document_repo_mock.delete.call_count == 0
+
+
+def test_delete_when_no_org_associated_with_entity(
+    document_repo_mock, app_user_repo_mock
+):
+    document_repo_mock.no_org = True
+    with pytest.raises(RepositoryError) as e:
+        ok = doc_service.delete("a.b.c.d", USER_EMAIL)
+        assert not ok
+
+    expected_msg = (
+        "The document import id a.b.c.d does not have an associated organisation"
+    )
+    assert e.value.message == expected_msg
+
+    assert document_repo_mock.get.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 1
+    assert app_user_repo_mock.is_superuser.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert document_repo_mock.delete.call_count == 0
+
+
+def test_delete_when_org_mismatch(document_repo_mock, app_user_repo_mock):
+    document_repo_mock.alternative_org = True
+    with pytest.raises(AuthorisationError) as e:
+        ok = doc_service.delete("a.b.c.d", USER_EMAIL)
+        assert not ok
+
+    expected_msg = "User 'test@cpr.org' is not authorised to delete document 'a.b.c.d'"
+    assert e.value.message == expected_msg
+
+    assert document_repo_mock.get.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 1
+    assert app_user_repo_mock.is_superuser.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
     assert document_repo_mock.delete.call_count == 0

--- a/tests/unit_tests/service/document/test_delete_document_service.py
+++ b/tests/unit_tests/service/document/test_delete_document_service.py
@@ -1,7 +1,7 @@
 import pytest
 
 import app.service.document as doc_service
-from app.errors import AuthorisationError, RepositoryError, ValidationError
+from app.errors import AuthorisationError, ValidationError
 
 USER_EMAIL = "test@cpr.org"
 
@@ -49,7 +49,7 @@ def test_delete_when_no_org_associated_with_entity(
     document_repo_mock, app_user_repo_mock
 ):
     document_repo_mock.no_org = True
-    with pytest.raises(RepositoryError) as e:
+    with pytest.raises(ValidationError) as e:
         ok = doc_service.delete("a.b.c.d", USER_EMAIL)
         assert not ok
 

--- a/tests/unit_tests/service/document/test_delete_document_service.py
+++ b/tests/unit_tests/service/document/test_delete_document_service.py
@@ -10,9 +10,9 @@ def test_delete(document_repo_mock, app_user_repo_mock):
     ok = doc_service.delete("a.b.c.d", USER_EMAIL)
     assert ok
     assert document_repo_mock.get.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
     assert app_user_repo_mock.get_org_id.call_count == 1
     assert app_user_repo_mock.is_superuser.call_count == 1
-    assert document_repo_mock.get_org_from_import_id.call_count == 1
     assert document_repo_mock.delete.call_count == 1
 
 
@@ -23,9 +23,9 @@ def test_delete_raises_when_invalid_id(document_repo_mock, app_user_repo_mock):
     expected_msg = f"The import id {import_id} is invalid!"
     assert e.value.message == expected_msg
     assert document_repo_mock.get.call_count == 0
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 0
     assert app_user_repo_mock.is_superuser.call_count == 0
-    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert document_repo_mock.delete.call_count == 0
 
 
@@ -39,9 +39,9 @@ def test_delete_when_missing(document_repo_mock, app_user_repo_mock):
     assert e.value.message == expected_msg
 
     assert document_repo_mock.get.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 0
     assert app_user_repo_mock.is_superuser.call_count == 0
-    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert document_repo_mock.delete.call_count == 0
 
 
@@ -59,9 +59,9 @@ def test_delete_when_no_org_associated_with_entity(
     assert e.value.message == expected_msg
 
     assert document_repo_mock.get.call_count == 1
-    assert app_user_repo_mock.get_org_id.call_count == 1
-    assert app_user_repo_mock.is_superuser.call_count == 1
     assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
     assert document_repo_mock.delete.call_count == 0
 
 
@@ -71,11 +71,13 @@ def test_delete_when_org_mismatch(document_repo_mock, app_user_repo_mock):
         ok = doc_service.delete("a.b.c.d", USER_EMAIL)
         assert not ok
 
-    expected_msg = "User 'test@cpr.org' is not authorised to delete document 'a.b.c.d'"
+    expected_msg = (
+        "User 'test@cpr.org' is not authorised to perform operation on 'a.b.c.d'"
+    )
     assert e.value.message == expected_msg
 
     assert document_repo_mock.get.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
     assert app_user_repo_mock.get_org_id.call_count == 1
     assert app_user_repo_mock.is_superuser.call_count == 1
-    assert document_repo_mock.get_org_from_import_id.call_count == 1
     assert document_repo_mock.delete.call_count == 0

--- a/tests/unit_tests/service/document/test_delete_document_service.py
+++ b/tests/unit_tests/service/document/test_delete_document_service.py
@@ -29,14 +29,10 @@ def test_delete_raises_when_invalid_id(document_repo_mock, app_user_repo_mock):
     assert document_repo_mock.delete.call_count == 0
 
 
-def test_delete_when_missing(document_repo_mock, app_user_repo_mock):
+def test_delete_returns_none_when_missing(document_repo_mock, app_user_repo_mock):
     document_repo_mock.return_empty = True
-    with pytest.raises(ValidationError) as e:
-        ok = doc_service.delete("a.b.c.d", USER_EMAIL)
-        assert not ok
-
-    expected_msg = "Could not find document a.b.c.d"
-    assert e.value.message == expected_msg
+    response = doc_service.delete("a.b.c.d", USER_EMAIL)
+    assert response is None
 
     assert document_repo_mock.get.call_count == 1
     assert document_repo_mock.get_org_from_import_id.call_count == 0

--- a/tests/unit_tests/service/document/test_get_document_service.py
+++ b/tests/unit_tests/service/document/test_get_document_service.py
@@ -16,7 +16,7 @@ def test_get(document_repo_mock):
 def test_get_returns_none(document_repo_mock):
     document_repo_mock.return_empty = True
     result = doc_service.get("id.1.2.3")
-    assert result is not None
+    assert result is None
     assert document_repo_mock.get.call_count == 1
 
 

--- a/tests/unit_tests/service/document/test_update_document_service.py
+++ b/tests/unit_tests/service/document/test_update_document_service.py
@@ -4,52 +4,82 @@ import app.service.document as doc_service
 from app.errors import RepositoryError, ValidationError
 from tests.helpers.document import create_document_write_dto
 
-# --- UPDATE
+USER_EMAIL = "test@cpr.org"
 
 
-def test_update(document_repo_mock):
+def test_update(document_repo_mock, app_user_repo_mock):
     document = doc_service.get("a.b.c.d")
     assert document is not None
+    document_repo_mock.get.call_count = 0
+    assert document_repo_mock.get.call_count == 0
 
     updated_doc = create_document_write_dto()
-    result = doc_service.update(document.import_id, updated_doc)
+    result = doc_service.update(document.import_id, updated_doc, USER_EMAIL)
     assert result is not None
+
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 1
+    assert app_user_repo_mock.is_superuser.call_count == 1
     assert document_repo_mock.update.call_count == 1
+    assert document_repo_mock.get.call_count == 1
 
 
-def test_update_when_missing(document_repo_mock):
+def test_update_when_missing(document_repo_mock, app_user_repo_mock):
     document = doc_service.get("a.b.c.d")
     assert document is not None
-    document_repo_mock.return_empty = True
+    document_repo_mock.get.call_count = 0
+    assert document_repo_mock.get.call_count == 0
 
+    document_repo_mock.return_empty = True
     updated_doc = create_document_write_dto()
     with pytest.raises(RepositoryError) as e:
-        doc_service.update(document.import_id, updated_doc)
+        doc_service.update(document.import_id, updated_doc, USER_EMAIL)
     assert e.value.message == "Error when updating document a.b.c.d"
+
+    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 1
+    assert app_user_repo_mock.is_superuser.call_count == 1
     assert document_repo_mock.update.call_count == 1
+    assert document_repo_mock.get.call_count == 0
 
 
-def test_update_raises_when_invalid_id(document_repo_mock):
+def test_update_raises_when_invalid_id(document_repo_mock, app_user_repo_mock):
     document = doc_service.get("a.b.c.d")
     assert document is not None  # needed to placate pyright
-    document.import_id = "invalid"
+    document_repo_mock.get.call_count = 0
+    assert document_repo_mock.get.call_count == 0
 
+    document.import_id = "invalid"
     updated_doc = create_document_write_dto()
     with pytest.raises(ValidationError) as e:
-        doc_service.update(document.import_id, updated_doc)
+        doc_service.update(document.import_id, updated_doc, USER_EMAIL)
+
     expected_msg = f"The import id {document.import_id} is invalid!"
     assert e.value.message == expected_msg
+
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
     assert document_repo_mock.update.call_count == 0
+    assert document_repo_mock.get.call_count == 0
 
 
-def test_update_raises_when_invalid_variant(document_repo_mock):
+def test_update_raises_when_invalid_variant(document_repo_mock, app_user_repo_mock):
     document = doc_service.get("a.b.c.d")
     assert document is not None  # needed to placate pyright
-    document.variant_name = ""
+    document_repo_mock.get.call_count = 0
+    assert document_repo_mock.get.call_count == 0
 
+    document.variant_name = ""
     updated_doc = create_document_write_dto(variant_name="")
     with pytest.raises(ValidationError) as e:
-        doc_service.update(document.import_id, updated_doc)
+        doc_service.update(document.import_id, updated_doc, USER_EMAIL)
+
     expected_msg = "Variant name is empty"
     assert e.value.message == expected_msg
+
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
     assert document_repo_mock.update.call_count == 0
+    assert document_repo_mock.get.call_count == 0

--- a/tests/unit_tests/service/family/test_delete_family_service.py
+++ b/tests/unit_tests/service/family/test_delete_family_service.py
@@ -20,9 +20,9 @@ def test_delete(family_repo_mock, app_user_repo_mock, organisation_repo_mock):
     ok = family_service.delete("a.b.c.d", USER_EMAIL)
     assert ok
     assert family_repo_mock.get.call_count == 1
+    assert organisation_repo_mock.get_id_from_name.call_count == 1
     assert app_user_repo_mock.get_org_id.call_count == 1
     assert app_user_repo_mock.is_superuser.call_count == 1
-    assert organisation_repo_mock.get_id_from_name.call_count == 1
     assert family_repo_mock.delete.call_count == 1
 
 
@@ -33,9 +33,9 @@ def test_delete_when_fam_missing(
     ok = family_service.delete("a.b.c.d", USER_EMAIL)
     assert not ok
     assert family_repo_mock.get.call_count == 1
+    assert organisation_repo_mock.get_id_from_name.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 0
     assert app_user_repo_mock.is_superuser.call_count == 0
-    assert organisation_repo_mock.get_id_from_name.call_count == 0
     assert family_repo_mock.delete.call_count == 0
 
 
@@ -48,9 +48,9 @@ def test_delete_raises_when_invalid_id(
     expected_msg = f"The import id {import_id} is invalid!"
     assert e.value.message == expected_msg
     assert family_repo_mock.get.call_count == 0
+    assert organisation_repo_mock.get_id_from_name.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 0
     assert app_user_repo_mock.is_superuser.call_count == 0
-    assert organisation_repo_mock.get_id_from_name.call_count == 0
     assert family_repo_mock.delete.call_count == 0
 
 
@@ -67,9 +67,9 @@ def test_delete_raises_when_organisation_invalid(
     assert e.value.message == expected_msg
 
     assert family_repo_mock.get.call_count == 1
-    assert app_user_repo_mock.get_org_id.call_count == 1
-    assert app_user_repo_mock.is_superuser.call_count == 1
     assert organisation_repo_mock.get_id_from_name.call_count == 1
+    assert app_user_repo_mock.get_org_id.call_count == 0
+    assert app_user_repo_mock.is_superuser.call_count == 0
     assert family_repo_mock.delete.call_count == 0
 
 
@@ -82,12 +82,12 @@ def test_delete_raises_when_family_organisation_mismatch_with_user_org(
         assert not ok
 
     expected_msg = (
-        f"User '{USER_EMAIL}' is not authorised to make changes to family 'a.b.c.d'"
+        f"User '{USER_EMAIL}' is not authorised to perform operation on 'a.b.c.d'"
     )
     assert e.value.message == expected_msg
 
     assert family_repo_mock.get.call_count == 1
+    assert organisation_repo_mock.get_id_from_name.call_count == 1
     assert app_user_repo_mock.get_org_id.call_count == 1
     assert app_user_repo_mock.is_superuser.call_count == 1
-    assert organisation_repo_mock.get_id_from_name.call_count == 1
     assert family_repo_mock.delete.call_count == 0


### PR DESCRIPTION
# Description

Check user org matches org the document belongs to on document update.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
