### PR TITLE
Bugfix/cant add doc to family

### DIFF
--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -482,17 +482,8 @@ def count(db: Session, org_id: Optional[int]) -> Optional[int]:
     return n_documents
 
 
-def get_org_from_import_id(
-    db: Session, import_id: str, is_create: bool = False
-) -> Optional[int]:
-    query = _get_query(db)
-    if is_create:
-        query = query.filter(FamilyDocument.family_import_id == import_id).distinct(
-            FamilyDocument.family_import_id
-        )
-    else:
-        query = query.filter(FamilyDocument.import_id == import_id)
-    result = query.one_or_none()
+def get_org_from_import_id(db: Session, import_id: str) -> Optional[int]:
+    result = _get_query(db).filter(FamilyDocument.import_id == import_id).one_or_none()
     if result is None:
         return None
     _, _, org, _, _ = result

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -493,7 +493,7 @@ def get_organisation(db: Session, family_import_id: str) -> Optional[Organisatio
         .join(FamilyCorpus, FamilyCorpus.corpus_import_id == Corpus.import_id)
         .filter(FamilyCorpus.family_import_id == family_import_id)
         .group_by(Organisation.id)
-        .one()
+        .one_or_none()
     )
 
 

--- a/app/repository/protocols.py
+++ b/app/repository/protocols.py
@@ -14,6 +14,7 @@ class FamilyRepo(Protocol):
     throw_timeout_error: bool = False
     is_superuser: bool = False
     invalid_org: bool = False
+    no_org: bool = False
 
     @staticmethod
     def all(db: Session, org_id: Optional[int]) -> list[FamilyReadDTO]:

--- a/app/repository/protocols.py
+++ b/app/repository/protocols.py
@@ -13,6 +13,7 @@ class FamilyRepo(Protocol):
     throw_repository_error: bool = False
     throw_timeout_error: bool = False
     is_superuser: bool = False
+    invalid_org: bool = False
 
     @staticmethod
     def all(db: Session, org_id: Optional[int]) -> list[FamilyReadDTO]:
@@ -51,4 +52,9 @@ class FamilyRepo(Protocol):
     @staticmethod
     def count(db: Session, org_id: Optional[int]) -> Optional[int]:
         """Counts all the families"""
+        ...
+
+    @staticmethod
+    def get_organisation(db: Session, family_import_id: str) -> Optional[int]:
+        """Get the organisation a family belongs to"""
         ...

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, cast
 
 from pydantic import ConfigDict, validate_call
 from sqlalchemy import exc
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 import app.clients.db.session as db_session
 import app.repository.document as document_repo
 import app.repository.document_file as file_repo
+import app.repository.family as family_repo
 import app.service.family as family_service
 from app.clients.aws.client import get_s3_client
 from app.errors import RepositoryError, ValidationError
@@ -198,9 +199,14 @@ def delete(
 
 
 def get_org_from_id(db: Session, import_id: str, is_create: bool = False) -> int:
-    org = document_repo.get_org_from_import_id(db, import_id, is_create)
+    if not is_create:
+        org = document_repo.get_org_from_import_id(db, import_id)
+    else:
+        org = family_repo.get_organisation(db, import_id)
+
     if org is None:
         msg = f"No organisation associated with import id {import_id}"
         _LOGGER.error(msg)
         raise ValidationError(msg)
-    return org
+
+    return org if isinstance(org, int) else cast(int, org.id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.8.2"
+version = "2.8.3"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/mocks/repos/__init__.py
+++ b/tests/mocks/repos/__init__.py
@@ -27,3 +27,6 @@ def create_mock_family_repo(family_repo, monkeypatch: MonkeyPatch, mocker):
 
     monkeypatch.setattr(family_repo, "count", mock_repo.count)
     mocker.spy(family_repo, "count")
+
+    monkeypatch.setattr(family_repo, "get_organisation", mock_repo.get_organisation)
+    mocker.spy(family_repo, "get_organisation")

--- a/tests/mocks/repos/document_repo.py
+++ b/tests/mocks/repos/document_repo.py
@@ -70,9 +70,7 @@ def mock_document_repo(document_repo, monkeypatch: MonkeyPatch, mocker):
             return 11
         return
 
-    def mock_get_org_from_import_id(
-        _, import_id: str, is_create: bool
-    ) -> Optional[int]:
+    def mock_get_org_from_import_id(_, import_id: str) -> Optional[int]:
         maybe_throw()
         if document_repo.no_org is True:
             return None

--- a/tests/mocks/repos/family_repo.py
+++ b/tests/mocks/repos/family_repo.py
@@ -72,6 +72,6 @@ def count(db: Session, org_id: Optional[int]) -> Optional[int]:
 
 def get_organisation(db: Session, family_import_id: str) -> Optional[int]:
     _maybe_throw()
-    if family_repo.return_empty:
+    if family_repo.no_org:
         return None
     return 987 if family_repo.invalid_org else 1

--- a/tests/mocks/repos/family_repo.py
+++ b/tests/mocks/repos/family_repo.py
@@ -68,3 +68,10 @@ def count(db: Session, org_id: Optional[int]) -> Optional[int]:
     if family_repo.is_superuser:
         return 22
     return 11
+
+
+def get_organisation(db: Session, family_import_id: str) -> Optional[int]:
+    _maybe_throw()
+    if family_repo.return_empty:
+        return None
+    return 987 if family_repo.invalid_org else 1

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -101,6 +101,7 @@ def family_repo_mock(monkeypatch, mocker):
     family_repo.return_empty = False
     family_repo.throw_repository_error = False
     family_repo.throw_timeout_error = False
+    family_repo.invalid_org = False
 
     create_mock_family_repo(family_repo, monkeypatch, mocker)
     yield family_repo

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -101,6 +101,7 @@ def family_repo_mock(monkeypatch, mocker):
     family_repo.return_empty = False
     family_repo.throw_repository_error = False
     family_repo.throw_timeout_error = False
+    family_repo.no_org = False
     family_repo.invalid_org = False
 
     create_mock_family_repo(family_repo, monkeypatch, mocker)

--- a/tests/unit_tests/service/document/test_create_document_service.py
+++ b/tests/unit_tests/service/document/test_create_document_service.py
@@ -13,7 +13,8 @@ def test_create(document_repo_mock, family_repo_mock, app_user_repo_mock):
     assert document is not None
 
     assert family_repo_mock.get.call_count == 1
-    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert family_repo_mock.get_organisation.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 1
     assert app_user_repo_mock.is_superuser.call_count == 1
     assert document_repo_mock.create.call_count == 1
@@ -27,7 +28,8 @@ def test_create_when_db_fails(document_repo_mock, family_repo_mock, app_user_rep
         doc_service.create(new_document, USER_EMAIL)
 
     assert family_repo_mock.get.call_count == 1
-    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert family_repo_mock.get_organisation.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 1
     assert app_user_repo_mock.is_superuser.call_count == 1
     assert document_repo_mock.create.call_count == 1
@@ -44,6 +46,7 @@ def test_create_raises_when_invalid_family_id(
     assert e.value.message == expected_msg
 
     assert family_repo_mock.get.call_count == 0
+    assert family_repo_mock.get_organisation.call_count == 0
     assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 0
     assert app_user_repo_mock.is_superuser.call_count == 0
@@ -60,6 +63,7 @@ def test_create_raises_when_blank_variant(
     assert e.value.message == expected_msg
 
     assert family_repo_mock.get.call_count == 0
+    assert family_repo_mock.get_organisation.call_count == 0
     assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 0
     assert app_user_repo_mock.is_superuser.call_count == 0
@@ -70,7 +74,7 @@ def test_create_when_no_org_associated_with_entity(
     document_repo_mock, family_repo_mock, app_user_repo_mock
 ):
     new_document = create_document_create_dto()
-    document_repo_mock.no_org = True
+    family_repo_mock.return_empty = True
     with pytest.raises(ValidationError) as e:
         ok = doc_service.create(new_document, USER_EMAIL)
         assert not ok
@@ -79,7 +83,8 @@ def test_create_when_no_org_associated_with_entity(
     assert e.value.message == expected_msg
 
     assert family_repo_mock.get.call_count == 1
-    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert family_repo_mock.get_organisation.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 0
     assert app_user_repo_mock.is_superuser.call_count == 0
     assert document_repo_mock.create.call_count == 0
@@ -89,7 +94,7 @@ def test_create_raises_when_org_mismatch(
     document_repo_mock, family_repo_mock, app_user_repo_mock
 ):
     new_document = create_document_create_dto()
-    document_repo_mock.alternative_org = True
+    family_repo_mock.invalid_org = True
     with pytest.raises(AuthorisationError) as e:
         ok = doc_service.create(new_document, USER_EMAIL)
         assert not ok
@@ -98,7 +103,8 @@ def test_create_raises_when_org_mismatch(
     assert e.value.message == expected_msg
 
     assert family_repo_mock.get.call_count == 1
-    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert family_repo_mock.get_organisation.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 1
     assert app_user_repo_mock.is_superuser.call_count == 1
     assert document_repo_mock.create.call_count == 0
@@ -108,13 +114,15 @@ def test_create_success_when_org_mismatch(
     document_repo_mock, family_repo_mock, app_user_repo_mock
 ):
     new_document = create_document_create_dto()
+    family_repo_mock.invalid_org = True
     app_user_repo_mock.superuser = True
     app_user_repo_mock.invalid_org = True
     document = doc_service.create(new_document, USER_EMAIL)
     assert document is not None
 
     assert family_repo_mock.get.call_count == 1
-    assert document_repo_mock.get_org_from_import_id.call_count == 1
+    assert family_repo_mock.get_organisation.call_count == 1
+    assert document_repo_mock.get_org_from_import_id.call_count == 0
     assert app_user_repo_mock.get_org_id.call_count == 1
     assert app_user_repo_mock.is_superuser.call_count == 1
     assert document_repo_mock.create.call_count == 1

--- a/tests/unit_tests/service/document/test_create_document_service.py
+++ b/tests/unit_tests/service/document/test_create_document_service.py
@@ -74,7 +74,7 @@ def test_create_when_no_org_associated_with_entity(
     document_repo_mock, family_repo_mock, app_user_repo_mock
 ):
     new_document = create_document_create_dto()
-    family_repo_mock.return_empty = True
+    family_repo_mock.no_org = True
     with pytest.raises(ValidationError) as e:
         ok = doc_service.create(new_document, USER_EMAIL)
         assert not ok


### PR DESCRIPTION
# Description

Fix 400 when trying to add new doc to a family
https://linear.app/climate-policy-radar/issue/PDCT-1186/cant-add-new-doc-to-family

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
