### PR TITLE
Feature/pdct 1161 user org not checked on family update

### DIFF
--- a/app/api/api_v1/routers/family.py
+++ b/app/api/api_v1/routers/family.py
@@ -132,6 +132,8 @@ async def update_family(
     """
     try:
         family = family_service.update(import_id, request.state.user.email, new_family)
+    except AuthorisationError as e:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=e.message)
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
     except RepositoryError as e:
@@ -140,8 +142,10 @@ async def update_family(
         )
 
     if family is None:
-        detail = f"Family not updated: {import_id}"
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Family not updated: {import_id}",
+        )
 
     return family
 

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -117,27 +117,25 @@ def update(
     if context is not None:
         context.error = f"Could not update family {import_id}"
 
+    # Get family we're going to update
+    family = get(import_id)
+    if family is None:
+        return None
+
     # Validate category
     category.validate(family_dto.category)
 
     # Validate geography
     geo_id = geography.get_id(db, family_dto.geography)
 
-    # Get family we're going to update
-    family = get(import_id)
-    if family is None:
-        raise ValidationError(f"Could not find family {import_id}")
-
     # Validate family belongs to same org as current user.
-    user_org_id = app_user.get_organisation(db, user_email)
-    org_id = organisation.get_id_from_name(db, family.organisation)
-    if org_id != user_org_id:
-        msg = "Current user does not belong to the organisation that owns family "
-        msg += import_id
-        raise ValidationError(msg)
+    entity_org_id: int = corpus.get_corpus_org_id(db, family.corpus_import_id)
+    app_user.raise_if_unauthorised_to_make_changes(
+        db, user_email, entity_org_id, family.corpus_import_id
+    )
 
     # Validate metadata.
-    metadata.validate(db, org_id, family_dto.metadata)
+    metadata.validate(db, entity_org_id, family_dto.metadata)
 
     # Validate that the collections we want to update are from the same organisation as
     # the current user and are in a valid format.
@@ -146,7 +144,7 @@ def update(
     collection.validate(all_cols_to_modify, db)
 
     collections_not_in_user_org = [
-        collection.get_org_from_id(db, c) != org_id for c in all_cols_to_modify
+        collection.get_org_from_id(db, c) != entity_org_id for c in all_cols_to_modify
     ]
     if len(collections_not_in_user_org) > 0 and any(collections_not_in_user_org):
         msg = "Organisation mismatch between some collections and the current user"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.8.4"
+version = "2.9.0"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.8.3"
+version = "2.8.4"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/mocks/services/family_service.py
+++ b/tests/mocks/services/family_service.py
@@ -45,6 +45,12 @@ def mock_family_service(family_service, monkeypatch: MonkeyPatch, mocker):
     def mock_update_family(
         import_id: str, user_email: str, data: FamilyWriteDTO
     ) -> Optional[FamilyReadDTO]:
+        if not family_service.valid:
+            raise ValidationError("Invalid data")
+
+        if family_service.org_mismatch and not family_service.superuser:
+            raise AuthorisationError("Org mismatch")
+
         if not family_service.missing:
             return create_family_read_dto(
                 import_id,

--- a/tests/unit_tests/routers/family/test_update_family.py
+++ b/tests/unit_tests/routers/family/test_update_family.py
@@ -33,3 +33,50 @@ def test_update_when_not_found(
     data = response.json()
     assert data["detail"] == "Family not updated: fam1"
     assert family_service_mock.update.call_count == 1
+
+
+def test_update_when_validation_error(
+    client: TestClient, family_service_mock, user_header_token
+):
+    family_service_mock.valid = False
+    new_data = create_family_write_dto("fam1").model_dump()
+    response = client.put(
+        "/api/v1/families/fam1",
+        json=new_data,
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    data = response.json()
+    assert data["detail"] == "Invalid data"
+    assert family_service_mock.update.call_count == 1
+
+
+def test_update_raises_when_corpus_org_different_to_usr_org(
+    client: TestClient, family_service_mock, user_header_token
+):
+    family_service_mock.org_mismatch = True
+    new_data = create_family_write_dto("fam1")
+    response = client.put(
+        "/api/v1/families/fam1",
+        json=new_data.model_dump(),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    data = response.json()
+    assert data["detail"] == "Org mismatch"
+    assert family_service_mock.update.call_count == 1
+
+
+def test_update_success_when_corpus_org_different_to_usr_org_super(
+    client: TestClient, family_service_mock, superuser_header_token
+):
+    family_service_mock.org_mismatch = True
+    family_service_mock.superuser = True
+    new_data = create_family_write_dto("fam1").model_dump()
+    response = client.put(
+        "/api/v1/families/fam1", json=new_data, headers=superuser_header_token
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["import_id"] == "fam1"
+    assert family_service_mock.update.call_count == 1


### PR DESCRIPTION
# Description

- Validate user org on family update

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
