### PR TITLE
Feature/pdct 1011 remove assumption of one organisation to one corpus

### DIFF
--- a/app/repository/corpus.py
+++ b/app/repository/corpus.py
@@ -10,8 +10,6 @@ _LOGGER = logging.getLogger(__name__)
 def get_corpus_org_id(db: Session, corpus_id: str) -> Optional[int]:
     """Get the organisation ID a corpus belongs to.
 
-    TODO: Will need to review as part of PDCT-1011.
-
     :param Session db: The DB session to connect to.
     :param str corpus_id: The corpus import ID we want to get the org
         for.

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -372,8 +372,6 @@ def create(db: Session, family: FamilyCreateDTO, geo_id: int, org_id: int) -> st
     )
     db.flush()
 
-    # TODO Validate that the metadata being added conforms to corpus type. PDCT-945
-
     # Add the metadata
     db.add(
         FamilyMetadata(

--- a/app/repository/metadata.py
+++ b/app/repository/metadata.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from app.model.general import Json
 
 
-def get_schema_for_org(db: Session, corpus_import_id: str) -> Optional[Json]:
+def get_schema_for_corpus(db: Session, corpus_import_id: str) -> Optional[Json]:
     """Gets the schema for an organisation.
 
     :param Session db: The DB session to query.

--- a/app/repository/metadata.py
+++ b/app/repository/metadata.py
@@ -6,12 +6,14 @@ from sqlalchemy.orm import Session
 from app.model.general import Json
 
 
-def get_schema_for_org(db: Session, org_id: int) -> Optional[Json]:
-    """
-    Gets the schema for an organisation.
+def get_schema_for_org(db: Session, corpus_import_id: str) -> Optional[Json]:
+    """Gets the schema for an organisation.
 
-    TODO: Remove assumption:
-    https://linear.app/climate-policy-radar/issue/PDCT-1011
+    :param Session db: The DB session to query.
+    :param str corpus_import_id: The import ID of the corpus to get the
+        schema for.
+    :return: None or a JSON object containing the valid metadata for the
+        given corpus.
     """
     corpus_type = (
         db.query(CorpusType)
@@ -19,7 +21,7 @@ def get_schema_for_org(db: Session, org_id: int) -> Optional[Json]:
             Corpus,
             Corpus.corpus_type_name == CorpusType.name,
         )
-        .filter(Corpus.organisation_id == org_id)
+        .filter(Corpus.import_id == corpus_import_id)
         .one_or_none()
     )
     if corpus_type is not None:

--- a/app/service/corpus.py
+++ b/app/service/corpus.py
@@ -9,9 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def get_corpus_org_id(db: Session, corpus_import_id: str) -> int:
-    """Get the organisation ID(s) a corpus belongs to.
-
-    TODO: Will need to review as part of PDCT-1011.
+    """Get the organisation ID a corpus belongs to.
 
     :param Session db: The DB session to connect to.
     :param str corpus_id: The corpus import ID we want to get the org

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -136,7 +136,7 @@ def update(
     )
 
     # Validate metadata.
-    metadata.validate(db, entity_org_id, family_dto.metadata)
+    metadata.validate(db, family.corpus_import_id, family_dto.metadata)
 
     # Validate that the collections we want to update are from the same organisation as
     # the current user and are in a valid format.
@@ -194,7 +194,7 @@ def create(
     entity_org_id: int = corpus.get_corpus_org_id(db, family.corpus_import_id)
 
     # Validate metadata.
-    metadata.validate(db, entity_org_id, family.metadata)
+    metadata.validate(db, family.corpus_import_id, family.metadata)
 
     # Validate collection ids.
     collections = set(family.collections)

--- a/app/service/metadata.py
+++ b/app/service/metadata.py
@@ -30,7 +30,7 @@ VALID_SCHEMA_KEYS = [KEY_ALLOW_ANY, KEY_ALLOW_BLANKS, KEY_ALLOWED_VALUES]
 
 
 def validate(db: Session, corpus_id: str, data: Json) -> bool:
-    schema = metadata_repo.get_schema_for_org(db, corpus_id)
+    schema = metadata_repo.get_schema_for_corpus(db, corpus_id)
     if schema is None:
         msg = f"Corpus {corpus_id} has no Taxonomy defined!"
         _LOGGER.error(msg)

--- a/app/service/metadata.py
+++ b/app/service/metadata.py
@@ -29,10 +29,10 @@ KEY_ALLOWED_VALUES = "allowed_values"
 VALID_SCHEMA_KEYS = [KEY_ALLOW_ANY, KEY_ALLOW_BLANKS, KEY_ALLOWED_VALUES]
 
 
-def validate(db: Session, org_id: int, data: Json) -> bool:
-    schema = metadata_repo.get_schema_for_org(db, org_id)
+def validate(db: Session, corpus_id: str, data: Json) -> bool:
+    schema = metadata_repo.get_schema_for_org(db, corpus_id)
     if schema is None:
-        msg = f"Organisation {org_id} has no Taxonomy defined!"
+        msg = f"Corpus {corpus_id} has no Taxonomy defined!"
         _LOGGER.error(msg)
         raise ValidationError(msg)
     return _validate(schema, data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.10.0"
+version = "2.10.1"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/helpers/family.py
+++ b/tests/helpers/family.py
@@ -55,7 +55,14 @@ def create_family_create_dto(
     corpus_import_id: str = "CCLW.corpus.i00000001.n0000",
 ) -> FamilyCreateDTO:
     if metadata is None:
-        metadata = {}
+        metadata = {
+            "topic": [],
+            "hazard": [],
+            "sector": [],
+            "keyword": [],
+            "framework": [],
+            "instrument": [],
+        }
     if collections is None:
         collections = []
     return FamilyCreateDTO(
@@ -78,7 +85,14 @@ def create_family_write_dto(
     collections: Optional[list[str]] = None,
 ) -> FamilyWriteDTO:
     if metadata is None:
-        metadata = {}
+        metadata = {
+            "topic": [],
+            "hazard": [],
+            "sector": [],
+            "keyword": [],
+            "framework": [],
+            "instrument": [],
+        }
     if collections is None:
         collections = []
     return FamilyWriteDTO(

--- a/tests/integration_tests/config/test_config.py
+++ b/tests/integration_tests/config/test_config.py
@@ -91,6 +91,7 @@ def test_get_config_cclw_corpora_correct(
 
     # Now sanity check the new corpora data
     cclw_corporas = data["corpora"]
+    assert len(data["corpora"]) == 1
 
     assert cclw_corporas[0]["corpus_import_id"] == "CCLW.corpus.i00000001.n0000"
     assert cclw_corporas[0]["corpus_type"] == "Laws and Policies"
@@ -99,13 +100,16 @@ def test_get_config_cclw_corpora_correct(
     assert cclw_corporas[0]["title"] == "CCLW national policies"
 
     cclw_taxonomy = cclw_corporas[0]["taxonomy"]
-    expected_cclw_taxonomy = {"color", "size"}
+    expected_cclw_taxonomy = {
+        "topic",
+        "keyword",
+        "hazard",
+        "framework",
+        "sector",
+        "instrument",
+    }
     expected_cclw_taxonomy.add("event_types")
     assert set(cclw_taxonomy) ^ expected_cclw_taxonomy == set()
-
-    expected_cclw_colours = ["green", "red", "pink", "blue"]
-    cclw_taxonomy_colours = cclw_taxonomy["color"]["allowed_values"]
-    assert set(cclw_taxonomy_colours) ^ set(expected_cclw_colours) == set()
 
 
 def test_get_config_unfccc_corpora_correct(
@@ -122,6 +126,7 @@ def test_get_config_unfccc_corpora_correct(
 
     # Now sanity check the new corpora data
     unfccc_corporas = data["corpora"]
+    assert len(data["corpora"]) == 1
 
     assert unfccc_corporas[0]["corpus_import_id"] == "UNFCCC.corpus.i00000001.n0000"
     assert unfccc_corporas[0]["corpus_type"] == "Intl. agreements"
@@ -156,13 +161,16 @@ def test_get_config_corpora_correct(
     assert corpora[0]["title"] == "CCLW national policies"
 
     cclw_taxonomy = corpora[0]["taxonomy"]
-    expected_cclw_taxonomy = {"color", "size"}
+    expected_cclw_taxonomy = {
+        "topic",
+        "keyword",
+        "hazard",
+        "framework",
+        "sector",
+        "instrument",
+    }
     expected_cclw_taxonomy.add("event_types")
     assert set(cclw_taxonomy) ^ expected_cclw_taxonomy == set()
-
-    expected_cclw_colours = ["green", "red", "pink", "blue"]
-    cclw_taxonomy_colours = cclw_taxonomy["color"]["allowed_values"]
-    assert set(cclw_taxonomy_colours) ^ set(expected_cclw_colours) == set()
 
     assert corpora[1]["corpus_import_id"] == "UNFCCC.corpus.i00000001.n0000"
     assert corpora[1]["corpus_type"] == "Intl. agreements"

--- a/tests/integration_tests/family/test_create.py
+++ b/tests/integration_tests/family/test_create.py
@@ -251,7 +251,7 @@ def test_create_family_when_org_mismatch(
     new_family = create_family_create_dto(
         title="Title",
         summary="test test test",
-        metadata={"author": "CPR", "author_type": "Party"},
+        metadata={"author": "CPR", "author_type": ["Party"]},
         corpus_import_id="UNFCCC.corpus.i00000001.n0000",
     )
     response = client.post(

--- a/tests/integration_tests/family/test_delete.py
+++ b/tests/integration_tests/family/test_delete.py
@@ -1,4 +1,3 @@
-import pytest
 from db_client.models.dfce import (
     CollectionFamily,
     DocumentStatus,
@@ -88,10 +87,6 @@ def test_delete_family_when_not_authenticated(client: TestClient, data_db: Sessi
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-@pytest.mark.skip(
-    "Fix PDCT-1115 - This test no longer works in the test environment, the rollback "
-    + "call returns the db to an empty state."
-)
 def test_delete_family_rollback(
     client: TestClient, data_db: Session, rollback_family_repo, user_header_token
 ):
@@ -106,6 +101,7 @@ def test_delete_family_rollback(
     )
     test_family = data_db.query(Family).filter(Family.import_id == "A.0.0.1").one()
     assert test_family.family_status != FamilyStatus.DELETED
+    assert rollback_family_repo.delete.call_count == 1
 
 
 def test_delete_family_when_not_found(

--- a/tests/integration_tests/family/test_update.py
+++ b/tests/integration_tests/family/test_update.py
@@ -20,7 +20,6 @@ def test_update_family(client: TestClient, data_db: Session, user_header_token):
         summary="just a test",
         geography="USA",
         category=FamilyCategory.UNFCCC,
-        metadata={"color": ["pink"], "size": [0]},
         collections=["C.0.0.3"],
     )
     response = client.put(
@@ -63,7 +62,6 @@ def test_update_family_slug(client: TestClient, data_db: Session, user_header_to
         summary="",
         geography="South Asia",
         category=FamilyCategory.UNFCCC,
-        metadata={"color": ["red"], "size": [3]},
         collections=["C.0.0.2"],
     )
 
@@ -119,7 +117,6 @@ def test_update_family_remove_collections(
         summary="",
         geography="Other",
         category=FamilyCategory.UNFCCC,
-        metadata={"color": ["red"], "size": [3]},
         collections=[],
     )
     response = client.put(
@@ -167,7 +164,6 @@ def test_update_family_append_collections(
         summary="",
         geography="Other",
         category=FamilyCategory.UNFCCC,
-        metadata={"color": ["red"], "size": [3]},
         collections=["C.0.0.2", "C.0.0.3"],
     )
     response = client.put(
@@ -218,7 +214,6 @@ def test_update_family_collections_to_one_that_does_not_exist(
         summary="",
         geography="Other",
         category=FamilyCategory.UNFCCC,
-        metadata={"color": ["red"], "size": [3]},
         collections=["C.0.0.2", "X.Y.Z.3"],
     )
     response = client.put(
@@ -263,7 +258,6 @@ def test_update_fails_family_when_user_org_different_to_family_org(
         summary="just a test",
         geography="USA",
         category=FamilyCategory.UNFCCC,
-        metadata={"color": ["pink"], "size": [0]},
         collections=[],
     )
     response = client.put(
@@ -296,7 +290,6 @@ def test_update_family_succeeds_when_user_org_different_to_family_org_super(
         summary="just a test",
         geography="USA",
         category=FamilyCategory.UNFCCC,
-        metadata={"color": ["pink"], "size": [0]},
         collections=["C.0.0.3"],
     )
     response = client.put(
@@ -337,7 +330,6 @@ def test_update_family_when_collection_org_different_to_family_org(
 ):
     setup_db(data_db)
     new_family = create_family_write_dto(
-        metadata={"color": ["pink"], "size": [0]},
         collections=["C.0.0.1", "C.0.0.2", "C.0.0.3"],
     )
     response = client.put(
@@ -370,7 +362,6 @@ def test_update_family_when_not_authenticated(client: TestClient, data_db: Sessi
         summary="just a test",
         geography="USA",
         category=FamilyCategory.UNFCCC,
-        metadata={"color": ["pink"], "size": [0]},
     )
     response = client.put("/api/v1/families/A.0.0.2", json=new_family.model_dump())
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -447,7 +438,6 @@ def test_update_family_when_not_found(
     new_family = create_family_write_dto(
         title="Updated Title",
         summary="just a test",
-        metadata={"color": ["pink"], "size": [0]},
     )
     response = client.put(
         "/api/v1/families/A.0.0.22",
@@ -466,7 +456,6 @@ def test_update_family_when_db_error(
     new_family = create_family_write_dto(
         title="Updated Title",
         summary="just a test",
-        metadata={"color": ["pink"], "size": [0]},
     )
     response = client.put(
         "/api/v1/families/A.0.0.22",
@@ -485,7 +474,6 @@ def test_update_family__invalid_geo(
     new_family = create_family_write_dto(
         title="Updated Title",
         summary="just a test",
-        metadata={"color": ["pink"], "size": [0]},
     )
     new_family.geography = "UK"
     response = client.put(
@@ -502,14 +490,29 @@ def test_update_family_metadata_if_changed(
     client: TestClient, data_db: Session, user_header_token
 ):
     setup_db(data_db)
-    expected_meta = {"color": ["pink"], "size": [23]}
     response = client.get(
         "/api/v1/families/A.0.0.2",
         headers=user_header_token,
     )
     assert response.status_code == status.HTTP_200_OK
     family_data = response.json()
-    assert {"color": ["green"], "size": [4]} == family_data["metadata"]
+    assert family_data["metadata"] == {
+        "topic": ["Mitigation"],
+        "hazard": [],
+        "sector": [],
+        "keyword": [],
+        "framework": [],
+        "instrument": [],
+    }
+
+    expected_meta = {
+        "topic": ["Adaptation"],
+        "hazard": ["Flood"],
+        "sector": [],
+        "keyword": [],
+        "framework": [],
+        "instrument": [],
+    }
     family_data["metadata"] = expected_meta
     response = client.put(
         "/api/v1/families/A.0.0.2", json=family_data, headers=user_header_token
@@ -517,7 +520,7 @@ def test_update_family_metadata_if_changed(
 
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert expected_meta == data["metadata"]
+    assert data["metadata"] == expected_meta
 
     metadata: FamilyMetadata = (
         data_db.query(FamilyMetadata)

--- a/tests/integration_tests/family/test_update.py
+++ b/tests/integration_tests/family/test_update.py
@@ -395,9 +395,9 @@ def test_update_family_idempotent_when_ok(
 
 
 def test_update_family_rollback(
-    client: TestClient, test_db: Session, rollback_family_repo, user_header_token
+    client: TestClient, data_db: Session, rollback_family_repo, user_header_token
 ):
-    setup_db(test_db)
+    setup_db(data_db)
     new_family = EXPECTED_FAMILIES[1]
     response = client.put(
         "/api/v1/families/A.0.0.2",
@@ -407,17 +407,17 @@ def test_update_family_rollback(
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
     db_family: Family = (
-        test_db.query(Family).filter(Family.import_id == "A.0.0.2").one()
+        data_db.query(Family).filter(Family.import_id == "A.0.0.2").one()
     )
     assert db_family.title != "Updated Title"
     assert db_family.description != "just a test"
 
-    db_slug = test_db.query(Slug).filter(Slug.family_import_id == "A.0.0.2").all()
+    db_slug = data_db.query(Slug).filter(Slug.family_import_id == "A.0.0.2").all()
     # Ensure no extra slug was created
     assert len(db_slug) == 1
 
     db_meta = (
-        test_db.query(FamilyMetadata)
+        data_db.query(FamilyMetadata)
         .filter(FamilyMetadata.family_import_id == "A.0.0.2")
         .all()
     )

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -404,29 +404,6 @@ def _setup_family_data(
 ) -> None:
     if configure_empty is True:
         return None
-    # Now a CorpusType
-    # valid_metadata = {
-    #     "color": {
-    #         "allow_any": False,
-    #         "allowed_values": ["green", "red", "pink", "blue"],
-    #     },
-    #     "size": {
-    #         "allow_any": True,
-    #         "allowed_values": [],
-    #     },
-    # }
-
-    # New Schema modification
-    # CorpusType
-    # cclw_ct = (
-    #     test_db.query(CorpusType)
-    #     .join(Corpus, Corpus.corpus_type_name == CorpusType.name)
-    #     .filter(Corpus.organisation_id == default_org_id)
-    #     .one()
-    # )
-    # cclw_ct.valid_metadata = valid_metadata
-    # test_db.add(cclw_ct)
-    # test_db.flush()
 
     for index in range(EXPECTED_NUM_FAMILIES):
         data = EXPECTED_FAMILIES[index]

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -19,7 +19,7 @@ from db_client.models.document.physical_document import (
     PhysicalDocument,
     PhysicalDocumentLanguage,
 )
-from db_client.models.organisation import Corpus, CorpusType
+from db_client.models.organisation import Corpus
 from db_client.models.organisation.users import AppUser, Organisation, OrganisationUser
 from sqlalchemy.orm import Session
 
@@ -33,7 +33,14 @@ EXPECTED_FAMILIES = [
         "geography": "Other",
         "category": "UNFCCC",
         "status": "Created",
-        "metadata": {"size": [3], "color": ["red"]},
+        "metadata": {
+            "topic": [],
+            "hazard": [],
+            "sector": [],
+            "keyword": [],
+            "framework": [],
+            "instrument": [],
+        },
         "organisation": "CCLW",
         "corpus_import_id": "CCLW.corpus.i00000001.n0000",
         "corpus_title": "CCLW national policies",
@@ -52,7 +59,14 @@ EXPECTED_FAMILIES = [
         "geography": "Other",
         "category": "UNFCCC",
         "status": "Created",
-        "metadata": {"size": [4], "color": ["green"]},
+        "metadata": {
+            "topic": ["Mitigation"],
+            "hazard": [],
+            "sector": [],
+            "keyword": [],
+            "framework": [],
+            "instrument": [],
+        },
         "organisation": "CCLW",
         "corpus_import_id": "CCLW.corpus.i00000001.n0000",
         "corpus_title": "CCLW national policies",
@@ -71,7 +85,7 @@ EXPECTED_FAMILIES = [
         "geography": "Other",
         "category": "UNFCCC",
         "status": "Created",
-        "metadata": {"size": [100], "color": ["blue"]},
+        "metadata": {"author": "CPR", "author_type": "Party"},
         "organisation": "UNFCCC",
         "corpus_import_id": "UNFCCC.corpus.i00000001.n0000",
         "corpus_title": "UNFCCC Submissions",
@@ -391,28 +405,28 @@ def _setup_family_data(
     if configure_empty is True:
         return None
     # Now a CorpusType
-    valid_metadata = {
-        "color": {
-            "allow_any": False,
-            "allowed_values": ["green", "red", "pink", "blue"],
-        },
-        "size": {
-            "allow_any": True,
-            "allowed_values": [],
-        },
-    }
+    # valid_metadata = {
+    #     "color": {
+    #         "allow_any": False,
+    #         "allowed_values": ["green", "red", "pink", "blue"],
+    #     },
+    #     "size": {
+    #         "allow_any": True,
+    #         "allowed_values": [],
+    #     },
+    # }
 
     # New Schema modification
     # CorpusType
-    cclw_ct = (
-        test_db.query(CorpusType)
-        .join(Corpus, Corpus.corpus_type_name == CorpusType.name)
-        .filter(Corpus.organisation_id == default_org_id)
-        .one()
-    )
-    cclw_ct.valid_metadata = valid_metadata
-    test_db.add(cclw_ct)
-    test_db.flush()
+    # cclw_ct = (
+    #     test_db.query(CorpusType)
+    #     .join(Corpus, Corpus.corpus_type_name == CorpusType.name)
+    #     .filter(Corpus.organisation_id == default_org_id)
+    #     .one()
+    # )
+    # cclw_ct.valid_metadata = valid_metadata
+    # test_db.add(cclw_ct)
+    # test_db.flush()
 
     for index in range(EXPECTED_NUM_FAMILIES):
         data = EXPECTED_FAMILIES[index]

--- a/tests/mocks/repos/metadata_repo.py
+++ b/tests/mocks/repos/metadata_repo.py
@@ -8,7 +8,16 @@ from app.model.general import Json
 def mock_metadata_repo(metadata_repo, monkeypatch: MonkeyPatch, mocker):
     def mock_get_schema_for_org(_, __) -> Optional[Json]:
         if not metadata_repo.error:
-            return {}
+            return {
+                "color": {
+                    "allow_any": False,
+                    "allowed_values": ["green", "red", "pink", "blue"],
+                },
+                "size": {
+                    "allow_any": True,
+                    "allowed_values": [],
+                },
+            }
 
     metadata_repo.error = False
     monkeypatch.setattr(metadata_repo, "get_schema_for_org", mock_get_schema_for_org)

--- a/tests/mocks/repos/metadata_repo.py
+++ b/tests/mocks/repos/metadata_repo.py
@@ -20,5 +20,5 @@ def mock_metadata_repo(metadata_repo, monkeypatch: MonkeyPatch, mocker):
             }
 
     metadata_repo.error = False
-    monkeypatch.setattr(metadata_repo, "get_schema_for_org", mock_get_schema_for_org)
-    mocker.spy(metadata_repo, "get_schema_for_org")
+    monkeypatch.setattr(metadata_repo, "get_schema_for_corpus", mock_get_schema_for_org)
+    mocker.spy(metadata_repo, "get_schema_for_corpus")

--- a/tests/mocks/repos/rollback_family_repo.py
+++ b/tests/mocks/repos/rollback_family_repo.py
@@ -1,12 +1,3 @@
-"""
-For the family repo - do that actual db operation then raise to force a rollback.
-
-Note this relies on the actual operation not doing the commit - rather the wrapper
-at the service layer (with_transaction). However, we have a bug that means this
-still needs fixing. See PDCT-1115
-
-"""
-
 from typing import Optional
 
 from pytest import MonkeyPatch

--- a/tests/unit_tests/service/family/test_create_family_service.py
+++ b/tests/unit_tests/service/family/test_create_family_service.py
@@ -28,7 +28,7 @@ def test_create(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 2
     assert family_repo_mock.create.call_count == 1
 
@@ -55,7 +55,7 @@ def test_create_repo_fails(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 2
     assert family_repo_mock.create.call_count == 1
 
@@ -80,7 +80,7 @@ def test_create_raises_when_category_invalid(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 0
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
     assert family_repo_mock.create.call_count == 0
 
@@ -105,7 +105,7 @@ def test_create_raises_when_metadata_invalid(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
     assert family_repo_mock.create.call_count == 0
 
@@ -131,7 +131,7 @@ def test_create_raises_when_collection_org_different_to_usr_org(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 2
     assert family_repo_mock.create.call_count == 0
 
@@ -156,7 +156,7 @@ def test_create_raises_when_corpus_missing(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 0
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
     assert family_repo_mock.create.call_count == 0
 
@@ -182,7 +182,7 @@ def test_create_when_no_org_associated_with_entity(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
     assert family_repo_mock.create.call_count == 0
 
@@ -207,7 +207,7 @@ def test_create_raises_when_corpus_org_different_to_usr_org(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 2
     assert family_repo_mock.create.call_count == 0
 
@@ -229,6 +229,6 @@ def test_create_success_when_corpus_org_different_to_usr_org_super(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.validate.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 2
     assert family_repo_mock.create.call_count == 1

--- a/tests/unit_tests/service/family/test_create_family_service.py
+++ b/tests/unit_tests/service/family/test_create_family_service.py
@@ -91,7 +91,7 @@ def test_create_raises_when_metadata_invalid(
     metadata_repo_mock.error = True
     with pytest.raises(ValidationError) as e:
         family_service.create(new_family, admin_user_context)
-    expected_msg = "Organisation 1 has no Taxonomy defined!"
+    expected_msg = "Corpus CCLW.corpus.i00000001.n0000 has no Taxonomy defined!"
     assert e.value.message == expected_msg
 
     assert geography_repo_mock.get_id_from_value.call_count == 1

--- a/tests/unit_tests/service/family/test_create_family_service.py
+++ b/tests/unit_tests/service/family/test_create_family_service.py
@@ -19,7 +19,9 @@ def test_create(
     corpus_repo_mock,
     admin_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     family = family_service.create(new_family, admin_user_context)
     assert family is not None
 
@@ -39,7 +41,9 @@ def test_create_repo_fails(
     corpus_repo_mock,
     admin_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     family_repo_mock.throw_repository_error = True
 
     with pytest.raises(RepositoryError) as e:
@@ -64,7 +68,9 @@ def test_create_raises_when_category_invalid(
     corpus_repo_mock,
     admin_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     new_family.category = "invalid"
     with pytest.raises(ValidationError) as e:
         family_service.create(new_family, admin_user_context)
@@ -87,7 +93,9 @@ def test_create_raises_when_metadata_invalid(
     corpus_repo_mock,
     admin_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     metadata_repo_mock.error = True
     with pytest.raises(ValidationError) as e:
         family_service.create(new_family, admin_user_context)
@@ -110,7 +118,9 @@ def test_create_raises_when_collection_org_different_to_usr_org(
     corpus_repo_mock,
     admin_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     collection_repo_mock.alternative_org = True
     with pytest.raises(AuthorisationError) as e:
         family_service.create(new_family, admin_user_context)
@@ -134,7 +144,9 @@ def test_create_raises_when_corpus_missing(
     corpus_repo_mock,
     admin_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     corpus_repo_mock.valid = False
     with pytest.raises(ValidationError) as e:
         family_service.create(new_family, admin_user_context)
@@ -157,7 +169,9 @@ def test_create_when_no_org_associated_with_entity(
     corpus_repo_mock,
     admin_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     corpus_repo_mock.error = True
     with pytest.raises(ValidationError) as e:
         family_service.create(new_family, admin_user_context)
@@ -181,7 +195,9 @@ def test_create_raises_when_corpus_org_different_to_usr_org(
     corpus_repo_mock,
     another_admin_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     with pytest.raises(AuthorisationError) as e:
         family_service.create(new_family, another_admin_user_context)
     expected_msg = "User 'another-admin@here.com' is not authorised to perform operation on 'CCLW.corpus.i00000001.n0000'"
@@ -204,7 +220,9 @@ def test_create_success_when_corpus_org_different_to_usr_org_super(
     corpus_repo_mock,
     super_user_context,
 ):
-    new_family = create_family_create_dto(collections=["x.y.z.1", "x.y.z.2"])
+    new_family = create_family_create_dto(
+        collections=["x.y.z.1", "x.y.z.2"], metadata={"size": [100], "color": ["blue"]}
+    )
     family = family_service.create(new_family, super_user_context)
     assert family is not None
 

--- a/tests/unit_tests/service/family/test_update_family_service.py
+++ b/tests/unit_tests/service/family/test_update_family_service.py
@@ -55,9 +55,6 @@ def test_update_when_family_missing(
     family_repo_mock.return_empty = True
     result = family_service.update("a.b.c.d", admin_user_context, updated_family)
     assert result is None
-    # with pytest.raises(ValidationError) as e:
-    #     family_service.update("a.b.c.d", admin_user_context, updated_family)
-    # assert e.value.message == "Could not find family a.b.c.d"
 
     assert family_repo_mock.update.call_count == 0
     assert geography_repo_mock.get_id_from_value.call_count == 0
@@ -199,7 +196,7 @@ def test_update_family_raises_when_metadata_invalid(
     metadata_repo_mock.error = True
     with pytest.raises(ValidationError) as e:
         family_service.update("a.b.c.d", admin_user_context, updated_family)
-    expected_msg = "Organisation 1 has no Taxonomy defined!"
+    expected_msg = "Corpus CCLW.corpus.i00000001.n0000 has no Taxonomy defined!"
     assert e.value.message == expected_msg
 
     assert family_repo_mock.get.call_count == 2

--- a/tests/unit_tests/service/family/test_update_family_service.py
+++ b/tests/unit_tests/service/family/test_update_family_service.py
@@ -35,7 +35,7 @@ def test_update(
     assert family_repo_mock.update.call_count == 1
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 3
     assert family_repo_mock.get.call_count == 2
 
@@ -65,7 +65,7 @@ def test_update_when_family_missing(
     assert family_repo_mock.get.call_count == 1
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 0
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
 
 
@@ -95,7 +95,7 @@ def test_update_raises_when_family_id_invalid(
     assert geography_repo_mock.get_id_from_value.call_count == 0
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 0
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
 
 
@@ -125,7 +125,7 @@ def test_update_raises_when_category_invalid(
     assert geography_repo_mock.get_id_from_value.call_count == 0
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 0
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
 
 
@@ -157,7 +157,7 @@ def test_update_raises_when_organisation_invalid(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
 
 
@@ -188,7 +188,7 @@ def test_update_family_raises_when_geography_invalid(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 0
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
 
 
@@ -215,7 +215,7 @@ def test_update_family_raises_when_metadata_invalid(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
 
 
@@ -244,7 +244,7 @@ def test_update_family_raises_when_collection_id_invalid(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.validate.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
 
@@ -274,7 +274,7 @@ def test_update_family_raises_when_collection_missing(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.validate.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
 
@@ -303,7 +303,7 @@ def test_update_family_raises_when_collection_org_different_to_usr_org(
     assert family_repo_mock.get.call_count == 2
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert family_repo_mock.update.call_count == 0
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 3
     assert collection_repo_mock.validate.call_count == 1
@@ -337,7 +337,7 @@ def test_update_raises_when_family_organisation_mismatch_with_user_org(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert family_repo_mock.update.call_count == 0
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 0
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 0
     assert collection_repo_mock.get_org_from_collection_id.call_count == 0
     assert collection_repo_mock.validate.call_count == 0
 
@@ -366,7 +366,7 @@ def test_update_success_when_family_organisation_mismatch_with_user_org(
     assert geography_repo_mock.get_id_from_value.call_count == 1
     assert family_repo_mock.get.call_count == 2
     assert corpus_repo_mock.get_corpus_org_id.call_count == 1
-    assert metadata_repo_mock.get_schema_for_org.call_count == 1
+    assert metadata_repo_mock.get_schema_for_corpus.call_count == 1
     assert collection_repo_mock.get_org_from_collection_id.call_count == 3
     assert collection_repo_mock.validate.call_count == 1
     assert family_repo_mock.update.call_count == 1

--- a/tests/unit_tests/service/family/test_update_family_service.py
+++ b/tests/unit_tests/service/family/test_update_family_service.py
@@ -25,7 +25,9 @@ def test_update(
     assert family_repo_mock.get.call_count == 0
 
     updated_family = create_family_write_dto(
-        title="UPDATED TITLE", collections=["x.y.z.2", "x.y.z.3"]
+        title="UPDATED TITLE",
+        collections=["x.y.z.2", "x.y.z.3"],
+        metadata={"size": [100], "color": ["blue"]},
     )
     result = family_service.update("a.b.c.d", admin_user_context, updated_family)
     assert result is not None
@@ -51,7 +53,9 @@ def test_update_when_family_missing(
     family_repo_mock.get.call_count = 0
     assert family_repo_mock.get.call_count == 0
 
-    updated_family = create_family_write_dto()
+    updated_family = create_family_write_dto(
+        metadata={"size": [100], "color": ["blue"]}
+    )
     family_repo_mock.return_empty = True
     result = family_service.update("a.b.c.d", admin_user_context, updated_family)
     assert result is None
@@ -78,7 +82,9 @@ def test_update_raises_when_family_id_invalid(
     family_repo_mock.get.call_count = 0
     assert family_repo_mock.get.call_count == 0
 
-    updated_family = create_family_write_dto()
+    updated_family = create_family_write_dto(
+        metadata={"size": [100], "color": ["blue"]}
+    )
     family.import_id = "invalid"
     with pytest.raises(ValidationError) as e:
         family_service.update(family.import_id, admin_user_context, updated_family)
@@ -106,7 +112,9 @@ def test_update_raises_when_category_invalid(
     family_repo_mock.get.call_count = 0
     assert family_repo_mock.get.call_count == 0
 
-    updated_family = create_family_write_dto(category="invalid")
+    updated_family = create_family_write_dto(
+        category="invalid", metadata={"size": [100], "color": ["blue"]}
+    )
 
     with pytest.raises(ValidationError) as e:
         family_service.update("a.b.c.d", admin_user_context, updated_family)
@@ -134,7 +142,9 @@ def test_update_raises_when_organisation_invalid(
     family_repo_mock.get.call_count = 0
     assert family_repo_mock.get.call_count == 0
 
-    updated_family = create_family_write_dto()
+    updated_family = create_family_write_dto(
+        metadata={"size": [100], "color": ["blue"]}
+    )
 
     corpus_repo_mock.error = True
     with pytest.raises(ValidationError) as e:
@@ -164,7 +174,9 @@ def test_update_family_raises_when_geography_invalid(
     family_repo_mock.get.call_count = 0
     assert family_repo_mock.get.call_count == 0
 
-    updated_family = create_family_write_dto()
+    updated_family = create_family_write_dto(
+        metadata={"size": [100], "color": ["blue"]}
+    )
 
     geography_repo_mock.error = True
     with pytest.raises(ValidationError) as e:
@@ -218,7 +230,10 @@ def test_update_family_raises_when_collection_id_invalid(
     family = family_service.get("a.b.c.d")
     assert family is not None  # needed to placate pyright
 
-    updated_family = create_family_write_dto(collections=["x.y.z.2", "col3", "col4"])
+    updated_family = create_family_write_dto(
+        collections=["x.y.z.2", "col3", "col4"],
+        metadata={"size": [100], "color": ["blue"]},
+    )
 
     with pytest.raises(ValidationError) as e:
         family_service.update("a.b.c.d", admin_user_context, updated_family)
@@ -245,7 +260,9 @@ def test_update_family_raises_when_collection_missing(
     family = family_service.get("a.b.c.d")
     assert family is not None  # needed to placate pyright
 
-    updated_family = create_family_write_dto()
+    updated_family = create_family_write_dto(
+        metadata={"size": [100], "color": ["blue"]}
+    )
 
     collection_repo_mock.missing = True
     with pytest.raises(ValidationError) as e:
@@ -273,7 +290,9 @@ def test_update_family_raises_when_collection_org_different_to_usr_org(
     family = family_service.get("a.b.c.d")
     assert family is not None  # needed to placate pyright
 
-    updated_family = create_family_write_dto(collections=["x.y.z.2", "x.y.z.3"])
+    updated_family = create_family_write_dto(
+        collections=["x.y.z.2", "x.y.z.3"], metadata={"size": [100], "color": ["blue"]}
+    )
 
     collection_repo_mock.alternative_org = True
     with pytest.raises(ValidationError) as e:
@@ -301,7 +320,9 @@ def test_update_raises_when_family_organisation_mismatch_with_user_org(
     family = family_service.get("a.b.c.d")
     assert family is not None  # needed to placate pyright
 
-    updated_family = create_family_write_dto(collections=["x.y.z.2", "x.y.z.3"])
+    updated_family = create_family_write_dto(
+        collections=["x.y.z.2", "x.y.z.3"], metadata={"size": [100], "color": ["blue"]}
+    )
 
     with pytest.raises(AuthorisationError) as e:
         ok = family_service.update(
@@ -335,7 +356,9 @@ def test_update_success_when_family_organisation_mismatch_with_user_org(
     family_repo_mock.get.call_count = 0
 
     updated_family = create_family_write_dto(
-        title="UPDATED TITLE", collections=["x.y.z.2", "x.y.z.3"]
+        title="UPDATED TITLE",
+        collections=["x.y.z.2", "x.y.z.3"],
+        metadata={"size": [100], "color": ["blue"]},
     )
     result = family_service.update("a.b.c.d", super_user_context, updated_family)
     assert result is not None


### PR DESCRIPTION
# Description

-  Remove assumption of one organisation to one corpus
- Update integration tests to correctly test CCLW taxonomy

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
