### PR TITLE
Bump db client to 3.7.2 & pyproject to 2.10.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -518,7 +518,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "db-client"
-version = "3.7.1"
+version = "3.7.2"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.9"
@@ -538,8 +538,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.7.1"
-resolved_reference = "c9813b9a997a3f8656725456d6f4bc473b0a8f4d"
+reference = "v3.7.2"
+resolved_reference = "1decd35791785b5ce12cce2dadec548150184cb4"
 
 [[package]]
 name = "dill"
@@ -3026,4 +3026,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6044a47ec3af8566ccbcf61ef0521431df9c512f21bf71fa50811ebb774b8c80"
+content-hash = "7abe9a62c289e6f003624e574d56c522858c3d2352b208284d8021d8f9f0c643"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.10.5"
+version = "2.10.6"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]
@@ -29,7 +29,7 @@ boto3 = "^1.28.46"
 moto = "^4.2.2"
 types-sqlalchemy = "^1.4.53.38"
 urllib3 = "^1.26.17"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.7.1" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.7.2" }
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.17.0"


### PR DESCRIPTION
# Description

Bump db client to 3.7.2 & pyproject to 2.10.6

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
