### PR TITLE
Feature/pdct 1245 Remove default metadata value if metadata was null & bump db_client to 3.8.5

### DIFF
--- a/app/model/document.py
+++ b/app/model/document.py
@@ -37,7 +37,7 @@ class DocumentWriteDTO(BaseModel):
 
     # From FamilyDocument
     variant_name: Optional[str]
-    role: Optional[str]
+    role: str
     type: Optional[str]
     metadata: Json
 

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -133,11 +133,7 @@ def _doc_to_dto(doc_query_return: ReadObj) -> DocumentReadDTO:
         created=cast(datetime, fdoc.created),
         last_modified=cast(datetime, fdoc.last_modified),
         slug=str(fdoc.slugs[0].name if len(fdoc.slugs) > 0 else ""),
-        metadata=(
-            cast(dict, fdoc.valid_metadata)
-            if fdoc.valid_metadata is not None
-            else {"role": []}
-        ),
+        metadata=cast(dict, fdoc.valid_metadata),
         physical_id=cast(int, pdoc.id),
         title=str(pdoc.title),
         md5_sum=str(pdoc.md5_sum) if pdoc.md5_sum is not None else None,

--- a/poetry.lock
+++ b/poetry.lock
@@ -518,7 +518,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "db-client"
-version = "3.8.4"
+version = "3.8.5"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.9"
@@ -538,8 +538,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.8.4"
-resolved_reference = "bc2c42dc1c924d51d88d972785a1931e28a8940b"
+reference = "v3.8.5"
+resolved_reference = "b71088e60125763e8b5316c91f4ec379ad2b9ef1"
 
 [[package]]
 name = "dill"
@@ -3026,4 +3026,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "49f8abd29ddc89468965c60b8cd351ad2da9e989eedc324975f15ae81c813070"
+content-hash = "167b183fe38f91da3b17a96f4a195b836fe5a7d40513bad6b77accd2cdc35d75"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ boto3 = "^1.28.46"
 moto = "^4.2.2"
 types-sqlalchemy = "^1.4.53.38"
 urllib3 = "^1.26.17"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.4" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.5" }
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.10.8"
+version = "2.10.9"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/document/test_create.py
+++ b/tests/integration_tests/document/test_create.py
@@ -338,7 +338,9 @@ def test_create_document_when_empty_variant(
     client: TestClient, data_db: Session, user_header_token
 ):
     setup_db(data_db)
-    new_document = create_document_create_dto(title="Empty variant", variant_name="")
+    new_document = create_document_create_dto(
+        title="Empty variant", family_import_id="A.0.0.2", variant_name=""
+    )
     response = client.post(
         "/api/v1/documents",
         json=new_document.model_dump(mode="json"),

--- a/tests/integration_tests/document/test_update.py
+++ b/tests/integration_tests/document/test_update.py
@@ -361,7 +361,7 @@ def test_update_document_raises_when_metadata_required_field_none(
         variant_name="Original Language",
         role="MAIN",
         type="Law",
-        metadata={"role": []},
+        metadata={"role": None},
         title="big title1",
         source_url=cast(AnyHttpUrl, "http://source1/"),
         user_language_name="English",


### PR DESCRIPTION
# Description

- Bump db_client version to 3.8.5 which makes family doc metadata not nullable after copying document role into metadata column object
- Remove default metadata value if metadata was null
- Add specific test cases to make sure update fails if metadata key value is None or empty when expected

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
