### PR TITLE
Feature/pdct 1243 remove references to familydocumentrole

### DIFF
--- a/app/model/config.py
+++ b/app/model/config.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 class DocumentConfig(BaseModel):
     """Everything you need to know about documents."""
 
-    roles: Sequence[str]
     types: Sequence[str]
     variants: Sequence[str]
 

--- a/app/model/document.py
+++ b/app/model/document.py
@@ -15,7 +15,6 @@ class DocumentReadDTO(BaseModel):
     family_import_id: str
     variant_name: Optional[str]
     status: DocumentStatus
-    role: Optional[str]
     type: Optional[str]
     slug: str
     created: datetime
@@ -37,7 +36,6 @@ class DocumentWriteDTO(BaseModel):
 
     # From FamilyDocument
     variant_name: Optional[str]
-    role: str
     type: Optional[str]
     metadata: Json
 
@@ -52,7 +50,6 @@ class DocumentCreateDTO(BaseModel):
     # From FamilyDocument
     family_import_id: str
     variant_name: Optional[str] = None
-    role: str
     type: Optional[str] = None
     metadata: Json
 

--- a/app/repository/config.py
+++ b/app/repository/config.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Sequence
 
 from db_client.models.base import AnyModel
-from db_client.models.dfce.family import FamilyDocumentRole, FamilyDocumentType, Variant
+from db_client.models.dfce.family import FamilyDocumentType, Variant
 from db_client.models.dfce.geography import Geography
 from db_client.models.document.physical_document import Language
 from db_client.models.organisation import Corpus, CorpusType, Organisation
@@ -92,12 +92,6 @@ def get(db: Session, user: UserContext) -> ConfigReadDTO:
 
     # Now Document config
     doc_config = DocumentConfig(
-        roles=[
-            doc_role.name
-            for doc_role in db.query(FamilyDocumentRole)
-            .order_by(FamilyDocumentRole.name)
-            .all()
-        ],
         types=[
             doc_type.name
             for doc_type in db.query(FamilyDocumentType)

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -95,7 +95,6 @@ def _dto_to_family_document_dict(dto: DocumentCreateDTO) -> dict:
         "physical_document_id": 0,
         "variant_name": dto.variant_name,
         "document_type": dto.type,
-        "document_role": dto.role,
         "valid_metadata": dto.metadata,
     }
 
@@ -128,7 +127,6 @@ def _doc_to_dto(doc_query_return: ReadObj) -> DocumentReadDTO:
         family_import_id=str(fdoc.family_import_id),
         variant_name=str(fdoc.variant_name) if fdoc.variant_name is not None else None,
         status=cast(DocumentStatus, fdoc.document_status),
-        role=str(fdoc.document_role) if fdoc.document_role is not None else None,
         type=str(fdoc.document_type) if fdoc.document_type is not None else None,
         created=cast(datetime, fdoc.created),
         last_modified=cast(datetime, fdoc.last_modified),
@@ -278,7 +276,6 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
         .where(FamilyDocument.import_id == original_fd.import_id)
         .values(
             variant_name=new_values["variant_name"],
-            document_role=new_values["role"],
             document_type=new_values["type"],
             valid_metadata=new_values["metadata"],
         ),

--- a/poetry.lock
+++ b/poetry.lock
@@ -518,7 +518,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "db-client"
-version = "3.8.5"
+version = "3.8.6"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.9"
@@ -538,8 +538,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.8.5"
-resolved_reference = "b71088e60125763e8b5316c91f4ec379ad2b9ef1"
+reference = "b92c0a9815c2f36af05409c2904935e351d8c84f"
+resolved_reference = "b92c0a9815c2f36af05409c2904935e351d8c84f"
 
 [[package]]
 name = "dill"
@@ -3026,4 +3026,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "167b183fe38f91da3b17a96f4a195b836fe5a7d40513bad6b77accd2cdc35d75"
+content-hash = "a5f373f33a87535d4d8943f9d201f4356b0f1701cd34aece70d53987b942819b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -538,8 +538,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "b92c0a9815c2f36af05409c2904935e351d8c84f"
-resolved_reference = "b92c0a9815c2f36af05409c2904935e351d8c84f"
+reference = "v3.8.6"
+resolved_reference = "1ea889f05a4b5a4c88232ed07285a17275413fd9"
 
 [[package]]
 name = "dill"
@@ -3026,4 +3026,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a5f373f33a87535d4d8943f9d201f4356b0f1701cd34aece70d53987b942819b"
+content-hash = "88101a67e5122bc46fa13f831f62b7ddece3040784b4cfc8a47046c544c493db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ boto3 = "^1.28.46"
 moto = "^4.2.2"
 types-sqlalchemy = "^1.4.53.38"
 urllib3 = "^1.26.17"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", rev = "b92c0a9815c2f36af05409c2904935e351d8c84f" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.6" }
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ boto3 = "^1.28.46"
 moto = "^4.2.2"
 types-sqlalchemy = "^1.4.53.38"
 urllib3 = "^1.26.17"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.5" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", rev = "b92c0a9815c2f36af05409c2904935e351d8c84f" }
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.17.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.10.9"
+version = "2.10.10"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/helpers/document.py
+++ b/tests/helpers/document.py
@@ -23,7 +23,6 @@ def create_document_create_dto(
     return DocumentCreateDTO(
         family_import_id=family_import_id,
         variant_name=variant_name,
-        role="MAIN",
         type="Law",
         metadata=metadata,
         title=title,
@@ -41,7 +40,6 @@ def create_document_write_dto(
         metadata = {"role": ["MAIN"]}
     return DocumentWriteDTO(
         variant_name=variant_name,
-        role="MAIN",
         type="Law",
         metadata=metadata,
         title=title,
@@ -64,7 +62,6 @@ def create_document_read_dto(
         family_import_id=family_import_id,
         variant_name=variant_name,
         status=DocumentStatus.CREATED,
-        role="MAIN",
         type="Law",
         metadata=metadata,
         slug="",

--- a/tests/integration_tests/config/test_config.py
+++ b/tests/integration_tests/config/test_config.py
@@ -62,7 +62,7 @@ def test_get_config_has_expected_shape(
     assert len(data["languages"]) == EXPECTED_LANGUAGES
 
     assert isinstance(data["document"], dict)
-    assert set(data["document"].keys()) == set(["roles", "types", "variants"])
+    assert set(data["document"].keys()) == set(["types", "variants"])
 
 
 def test_get_config_has_correct_number_corpora_super(
@@ -246,7 +246,7 @@ def test_config_documents(client: TestClient, data_db: Session, user_header_toke
     # Now sanity check the data
     #
     # Documents..
-    assert "AMENDMENT" in data["document"]["roles"]
+    assert "roles" not in data["document"].keys()
     assert "Action Plan" in data["document"]["types"]
     assert "Translation" in data["document"]["variants"]
 

--- a/tests/integration_tests/document/test_update.py
+++ b/tests/integration_tests/document/test_update.py
@@ -485,7 +485,6 @@ def test_update_document_idempotent(
     doc = EXPECTED_DOCUMENTS[0]
     document = {
         "variant_name": doc["variant_name"],
-        "role": doc["role"],
         "type": doc["type"],
         "metadata": doc["metadata"],
         "title": doc["title"],

--- a/tests/integration_tests/document/test_update.py
+++ b/tests/integration_tests/document/test_update.py
@@ -43,7 +43,6 @@ def test_update_document_super(
     setup_db(data_db)
     new_document = DocumentWriteDTO(
         variant_name="Translation",
-        role="SUMMARY",
         type="Annex",
         metadata={"role": ["SUMMARY"]},
         title="Updated Title",
@@ -59,7 +58,6 @@ def test_update_document_super(
     data = response.json()
     assert data["import_id"] == "D.0.0.2"
     assert data["variant_name"] == "Translation"
-    assert data["role"] == "SUMMARY"
     assert data["metadata"] == {"role": ["SUMMARY"]}
     assert data["type"] == "Annex"
     assert data["title"] == "Updated Title"
@@ -70,7 +68,6 @@ def test_update_document_super(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.2")
     assert fd.import_id == "D.0.0.2"
     assert fd.variant_name == "Translation"
-    assert fd.document_role == "SUMMARY"
     assert fd.document_type == "Annex"
     assert fd.valid_metadata == {"role": ["SUMMARY"]}
     assert pd.title == "Updated Title"
@@ -100,7 +97,6 @@ def test_update_document_cclw(client: TestClient, data_db: Session, user_header_
     setup_db(data_db)
     new_document = DocumentWriteDTO(
         variant_name="Translation",
-        role="SUMMARY",
         type="Annex",
         metadata={"role": ["SUMMARY"]},
         title="Updated Title",
@@ -116,7 +112,6 @@ def test_update_document_cclw(client: TestClient, data_db: Session, user_header_
     data = response.json()
     assert data["import_id"] == "D.0.0.3"
     assert data["variant_name"] == "Translation"
-    assert data["role"] == "SUMMARY"
     assert data["type"] == "Annex"
     assert data["metadata"] == {"role": ["SUMMARY"]}
     assert data["title"] == "Updated Title"
@@ -127,7 +122,6 @@ def test_update_document_cclw(client: TestClient, data_db: Session, user_header_
     fd, pd = _get_doc_tuple(data_db, "D.0.0.3")
     assert fd.import_id == "D.0.0.3"
     assert fd.variant_name == "Translation"
-    assert fd.document_role == "SUMMARY"
     assert fd.document_type == "Annex"
     assert fd.valid_metadata == {"role": ["SUMMARY"]}
     assert pd.title == "Updated Title"
@@ -159,7 +153,6 @@ def test_update_document_unfccc(
     setup_db(data_db)
     new_document = DocumentWriteDTO(
         variant_name="Translation",
-        role="SUMMARY",
         type="Annex",
         metadata={"role": ["SUMMARY"]},
         title="Updated Title",
@@ -175,7 +168,6 @@ def test_update_document_unfccc(
     data = response.json()
     assert data["import_id"] == "D.0.0.2"
     assert data["variant_name"] == "Translation"
-    assert data["role"] == "SUMMARY"
     assert data["metadata"] == {"role": ["SUMMARY"]}
     assert data["type"] == "Annex"
     assert data["title"] == "Updated Title"
@@ -186,7 +178,6 @@ def test_update_document_unfccc(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.2")
     assert fd.import_id == "D.0.0.2"
     assert fd.variant_name == "Translation"
-    assert fd.document_role == "SUMMARY"
     assert fd.document_type == "Annex"
     assert fd.valid_metadata == {"role": ["SUMMARY"]}
     assert pd.title == "Updated Title"
@@ -220,7 +211,6 @@ def test_update_document_no_source_url(
     # Keep all values apart from the Source URL the same.
     new_document = DocumentWriteDTO(
         variant_name="Original Language",
-        role="MAIN",
         type="Law",
         metadata={"role": ["MAIN"]},
         title="big title1",
@@ -237,7 +227,6 @@ def test_update_document_no_source_url(
     data = response.json()
     assert data["import_id"] == "D.0.0.1"
     assert data["variant_name"] == "Original Language"
-    assert data["role"] == "MAIN"
     assert data["type"] == "Law"
     assert data["title"] == "big title1"
     assert data["source_url"] == new_document.source_url
@@ -246,7 +235,6 @@ def test_update_document_no_source_url(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.1")
     assert fd.import_id == "D.0.0.1"
     assert fd.variant_name == "Original Language"
-    assert fd.document_role == "MAIN"
     assert fd.document_type == "Law"
     assert fd.valid_metadata == {"role": ["MAIN"]}
     assert pd.title == "big title1"
@@ -272,7 +260,6 @@ def test_update_document_raises_when_metadata_invalid(
     # Keep all values apart from the metadata the same.
     new_document = DocumentWriteDTO(
         variant_name="Original Language",
-        role="MAIN",
         type="Law",
         metadata={"color": ["pink"]},
         title="big title1",
@@ -303,7 +290,6 @@ def test_update_document_raises_when_metadata_invalid(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.1")
     assert fd.import_id == "D.0.0.1"
     assert fd.variant_name == "Original Language"
-    assert fd.document_role == "MAIN"
     assert fd.document_type == "Law"
     assert fd.valid_metadata == {"role": ["MAIN"]}
     assert pd.title == "big title1"
@@ -318,7 +304,6 @@ def test_update_document_raises_when_metadata_required_field_blank(
     # Keep all values apart from the metadata the same.
     new_document = DocumentWriteDTO(
         variant_name="Original Language",
-        role="MAIN",
         type="Law",
         metadata={"role": []},
         title="big title1",
@@ -344,7 +329,6 @@ def test_update_document_raises_when_metadata_required_field_blank(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.1")
     assert fd.import_id == "D.0.0.1"
     assert fd.variant_name == "Original Language"
-    assert fd.document_role == "MAIN"
     assert fd.document_type == "Law"
     assert fd.valid_metadata == {"role": ["MAIN"]}
     assert pd.title == "big title1"
@@ -359,7 +343,6 @@ def test_update_document_raises_when_metadata_required_field_none(
     # Keep all values apart from the metadata the same.
     new_document = DocumentWriteDTO(
         variant_name="Original Language",
-        role="MAIN",
         type="Law",
         metadata={"role": None},
         title="big title1",
@@ -386,7 +369,6 @@ def test_update_document_raises_when_metadata_required_field_none(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.1")
     assert fd.import_id == "D.0.0.1"
     assert fd.variant_name == "Original Language"
-    assert fd.document_role == "MAIN"
     assert fd.document_type == "Law"
     assert fd.valid_metadata == {"role": ["MAIN"]}
     assert pd.title == "big title1"
@@ -401,7 +383,6 @@ def test_update_document_remove_variant(
     # Keep all values apart from the variant the same.
     new_document = DocumentWriteDTO(
         variant_name=None,
-        role="MAIN",
         type="Law",
         metadata={"role": ["MAIN"]},
         title="title2",
@@ -417,7 +398,6 @@ def test_update_document_remove_variant(
     data = response.json()
     assert data["import_id"] == "D.0.0.2"
     assert data["variant_name"] is None
-    assert data["role"] == "MAIN"
     assert data["type"] == "Law"
     assert data["title"] == "title2"
     assert data["source_url"] == "http://update_source/"
@@ -425,7 +405,6 @@ def test_update_document_remove_variant(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.2")
     assert fd.import_id == "D.0.0.2"
     assert fd.variant_name is None
-    assert fd.document_role == "MAIN"
     assert fd.document_type == "Law"
     assert pd.title == "title2"
     assert pd.source_url == "http://update_source/"
@@ -449,7 +428,6 @@ def test_update_document_remove_user_language(
     # Keep all values apart from the language the same as in setup_db.py.
     new_document = DocumentWriteDTO(
         variant_name="Original Language",
-        role="MAIN",
         type="Law",
         metadata={"role": ["MAIN"]},
         title="big title1",
@@ -465,7 +443,6 @@ def test_update_document_remove_user_language(
     data = response.json()
     assert data["import_id"] == "D.0.0.1"
     assert data["variant_name"] == "Original Language"
-    assert data["role"] == "MAIN"
     assert data["type"] == "Law"
     assert data["title"] == "big title1"
     assert data["source_url"] == "http://update_source/"
@@ -474,7 +451,6 @@ def test_update_document_remove_user_language(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.1")
     assert fd.import_id == "D.0.0.1"
     assert fd.variant_name == "Original Language"
-    assert fd.document_role == "MAIN"
     assert fd.document_type == "Law"
     assert fd.valid_metadata == {"role": ["MAIN"]}
     assert pd.title == "big title1"
@@ -595,7 +571,6 @@ def test_update_document_blank_variant(
     setup_db(data_db)
     new_document = DocumentWriteDTO(
         variant_name="",
-        role="SUMMARY",
         type="Annex",
         metadata={"role": ["SUMMARY"]},
         title="Updated Title",
@@ -618,7 +593,6 @@ def test_update_document_idempotent_user_language(
     setup_db(data_db)
     new_document = DocumentWriteDTO(
         variant_name="Original Language",
-        role="MAIN",
         type="Law",
         metadata={"role": ["MAIN"]},
         title="title2",
@@ -634,7 +608,6 @@ def test_update_document_idempotent_user_language(
     data = response.json()
     assert data["import_id"] == "D.0.0.2"
     assert data["variant_name"] == "Original Language"
-    assert data["role"] == "MAIN"
     assert data["type"] == "Law"
     assert data["title"] == "title2"
     assert data["source_url"] == "http://update_source/"
@@ -643,7 +616,6 @@ def test_update_document_idempotent_user_language(
     fd, pd = _get_doc_tuple(data_db, "D.0.0.2")
     assert fd.import_id == "D.0.0.2"
     assert fd.variant_name == "Original Language"
-    assert fd.document_role == "MAIN"
     assert fd.document_type == "Law"
     assert fd.valid_metadata == {"role": ["MAIN"]}
     assert pd.title == "title2"

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -138,7 +138,6 @@ EXPECTED_DOCUMENTS = [
         "family_import_id": "A.0.0.3",
         "variant_name": "Original Language",
         "status": "Created",
-        "role": "MAIN",
         "type": "Law",
         "metadata": {
             "role": ["MAIN"],
@@ -157,7 +156,6 @@ EXPECTED_DOCUMENTS = [
         "family_import_id": "A.0.0.3",
         "variant_name": "Original Language",
         "status": "Created",
-        "role": "MAIN",
         "type": "Law",
         "metadata": {
             "role": ["MAIN"],
@@ -176,7 +174,6 @@ EXPECTED_DOCUMENTS = [
         "family_import_id": "A.0.0.2",
         "variant_name": "Original Language",
         "status": "Created",
-        "role": "MAIN",
         "type": "Law",
         "metadata": {
             "role": ["MAIN"],
@@ -497,7 +494,6 @@ def _setup_document_data(test_db: Session, configure_empty: bool = False) -> Non
                 variant_name=data["variant_name"],
                 document_status=data["status"],
                 document_type=data["type"],
-                document_role=data["role"],
                 valid_metadata=data["metadata"],
             )
             test_db.add(fd)


### PR DESCRIPTION
# Description

- Remove references to familydocumentrole
- Remove role from DTOs in favour of metadata["role"]
- Update config object shape
- Update tests

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
