### PR TITLE
Feature/pdct 1244 remove references to familydocumenttype

### DIFF
--- a/app/model/config.py
+++ b/app/model/config.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 class DocumentConfig(BaseModel):
     """Everything you need to know about documents."""
 
-    types: Sequence[str]
     variants: Sequence[str]
 
 

--- a/app/model/document.py
+++ b/app/model/document.py
@@ -16,7 +16,6 @@ class DocumentReadDTO(BaseModel):
     corpus_type: str
     variant_name: Optional[str]
     status: DocumentStatus
-    type: Optional[str]
     slug: str
     created: datetime
     last_modified: datetime
@@ -37,7 +36,6 @@ class DocumentWriteDTO(BaseModel):
 
     # From FamilyDocument
     variant_name: Optional[str]
-    type: Optional[str]
     metadata: Json
 
     title: str
@@ -51,7 +49,6 @@ class DocumentCreateDTO(BaseModel):
     # From FamilyDocument
     family_import_id: str
     variant_name: Optional[str] = None
-    type: Optional[str] = None
     metadata: Json
 
     # From PhysicalDocument

--- a/app/repository/config.py
+++ b/app/repository/config.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Sequence
 
 from db_client.models.base import AnyModel
-from db_client.models.dfce.family import FamilyDocumentType, Variant
+from db_client.models.dfce.family import Variant
 from db_client.models.dfce.geography import Geography
 from db_client.models.document.physical_document import Language
 from db_client.models.organisation import Corpus, CorpusType, Organisation
@@ -92,12 +92,6 @@ def get(db: Session, user: UserContext) -> ConfigReadDTO:
 
     # Now Document config
     doc_config = DocumentConfig(
-        types=[
-            doc_type.name
-            for doc_type in db.query(FamilyDocumentType)
-            .order_by(FamilyDocumentType.name)
-            .all()
-        ],
         variants=[
             variant.variant_name
             for variant in db.query(Variant).order_by(Variant.variant_name).all()

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -105,7 +105,6 @@ def _dto_to_family_document_dict(dto: DocumentCreateDTO) -> dict:
         "family_import_id": dto.family_import_id,
         "physical_document_id": 0,
         "variant_name": dto.variant_name,
-        "document_type": dto.type,
         "valid_metadata": dto.metadata,
     }
 
@@ -139,7 +138,6 @@ def _doc_to_dto(doc_query_return: ReadObj) -> DocumentReadDTO:
         corpus_type=str(corpus_type.name),
         variant_name=str(fdoc.variant_name) if fdoc.variant_name is not None else None,
         status=cast(DocumentStatus, fdoc.document_status),
-        type=str(fdoc.document_type) if fdoc.document_type is not None else None,
         created=cast(datetime, fdoc.created),
         last_modified=cast(datetime, fdoc.last_modified),
         slug=str(fdoc.slugs[0].name if len(fdoc.slugs) > 0 else ""),
@@ -288,7 +286,6 @@ def update(db: Session, import_id: str, document: DocumentWriteDTO) -> bool:
         .where(FamilyDocument.import_id == original_fd.import_id)
         .values(
             variant_name=new_values["variant_name"],
-            document_type=new_values["type"],
             valid_metadata=new_values["metadata"],
         ),
     ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -518,7 +518,7 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "db-client"
-version = "3.8.8"
+version = "3.8.9"
 description = "All things to do with the datamodel and its storage. Including alembic migrations and datamodel code."
 optional = false
 python-versions = "^3.9"
@@ -538,8 +538,8 @@ SQLAlchemy-Utils = "^0.38.2"
 [package.source]
 type = "git"
 url = "https://github.com/climatepolicyradar/navigator-db-client.git"
-reference = "v3.8.8"
-resolved_reference = "bb3bca6206f20284529dcbb2f89867f08313a7cb"
+reference = "v3.8.9"
+resolved_reference = "a6985c6d42be5fd5549deb693b60fd7b2694b97a"
 
 [[package]]
 name = "dill"
@@ -3026,4 +3026,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d349b4d592498140f9f6137095e75c64d905f947500d566d73a76866d9858a11"
+content-hash = "728ed47ae543197a49b85e91e75825ad3ceb179600ca1d316f0ace70aad804a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.10.13"
+version = "2.10.14"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ boto3 = "^1.28.46"
 moto = "^4.2.2"
 types-sqlalchemy = "^1.4.53.38"
 urllib3 = "^1.26.17"
-db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.8" }
+db-client = { git = "https://github.com/climatepolicyradar/navigator-db-client.git", tag = "v3.8.9" }
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.17.0"

--- a/tests/integration_tests/config/test_config.py
+++ b/tests/integration_tests/config/test_config.py
@@ -62,7 +62,7 @@ def test_get_config_has_expected_shape(
     assert len(data["languages"]) == EXPECTED_LANGUAGES
 
     assert isinstance(data["document"], dict)
-    assert set(data["document"].keys()) == set(["types", "variants"])
+    assert set(data["document"].keys()) == set(["variants"])
 
 
 def test_get_config_has_correct_number_corpora_super(

--- a/tests/integration_tests/config/test_config.py
+++ b/tests/integration_tests/config/test_config.py
@@ -247,7 +247,7 @@ def test_config_documents(client: TestClient, data_db: Session, user_header_toke
     #
     # Documents..
     assert "roles" not in data["document"].keys()
-    assert "Action Plan" in data["document"]["types"]
+    assert "types" not in data["document"].keys()
     assert "Translation" in data["document"]["variants"]
 
 

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -139,7 +139,6 @@ EXPECTED_DOCUMENTS = [
         "corpus_type": "Intl. agreements",
         "variant_name": "Original Language",
         "status": "Created",
-        "type": "Law",
         "metadata": {"role": ["MAIN"], "type": ["Law"]},
         "slug": "",
         "title": "big title1",
@@ -156,7 +155,6 @@ EXPECTED_DOCUMENTS = [
         "corpus_type": "Intl. agreements",
         "variant_name": "Original Language",
         "status": "Created",
-        "type": "Law",
         "metadata": {"role": ["MAIN"], "type": ["Law"]},
         "slug": "",
         "title": "title2",
@@ -173,7 +171,6 @@ EXPECTED_DOCUMENTS = [
         "corpus_type": "Laws and Policies",
         "variant_name": "Original Language",
         "status": "Created",
-        "type": "Law",
         "metadata": {"role": ["MAIN"], "type": ["Law"]},
         "slug": "",
         "title": "title3",
@@ -490,7 +487,6 @@ def _setup_document_data(test_db: Session, configure_empty: bool = False) -> Non
                 import_id=data["import_id"],
                 variant_name=data["variant_name"],
                 document_status=data["status"],
-                document_type=data["type"],  # TODO Remove PDCT-1244
                 valid_metadata=data["metadata"],
             )
             test_db.add(fd)


### PR DESCRIPTION
# Description

- Bump db client to 3.8.9
- Remove type from document DTOs
- Remove document type from config endpoint

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
