### PR TITLE
Rename 'query_params' to 'search_params' in service & repo layer

### DIFF
--- a/app/repository/collection.py
+++ b/app/repository/collection.py
@@ -138,13 +138,13 @@ def get(db: Session, import_id: str) -> Optional[CollectionReadDTO]:
 
 
 def search(
-    db: Session, query_params: dict[str, Union[str, int]], org_id: Optional[int]
+    db: Session, search_params: dict[str, Union[str, int]], org_id: Optional[int]
 ) -> list[CollectionReadDTO]:
     """
     Gets a list of collections from the repo searching given fields.
 
     :param db Session: the database connection
-    :param dict query_params: Any search terms to filter on specified
+    :param dict search_params: Any search terms to filter on specified
         fields (title & summary by default if 'q' specified).
     :param org_id Optional[int]: the ID of the organisation the user belongs to
     :raises HTTPException: If a DB error occurs a 503 is returned.
@@ -153,8 +153,8 @@ def search(
     :return list[CollectionResponse]: A list of matching collections.
     """
     search = []
-    if "q" in query_params.keys():
-        term = f"%{escape_like(query_params['q'])}%"
+    if "q" in search_params.keys():
+        term = f"%{escape_like(search_params['q'])}%"
         search.append(
             or_(Collection.title.ilike(term), Collection.description.ilike(term))
         )
@@ -166,7 +166,7 @@ def search(
             query = query.filter(Organisation.id == org_id)
         found = (
             query.order_by(desc(Collection.last_modified))
-            .limit(query_params["max_results"])
+            .limit(search_params["max_results"])
             .all()
         )
     except OperationalError as e:

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -193,13 +193,13 @@ def get(db: Session, import_id: str) -> Optional[DocumentReadDTO]:
 
 
 def search(
-    db: Session, query_params: dict[str, Union[str, int]], org_id: Optional[int]
+    db: Session, search_params: dict[str, Union[str, int]], org_id: Optional[int]
 ) -> list[DocumentReadDTO]:
     """
     Gets a list of documents from the repository searching the title.
 
     :param db Session: the database connection
-    :param dict query_params: Any search terms to filter on specified
+    :param dict search_params: Any search terms to filter on specified
         fields (title by default if 'q' specified).
     :param org_id Optional[int]: the ID of the organisation the user belongs to
     :raises HTTPException: If a DB error occurs a 503 is returned.
@@ -208,8 +208,8 @@ def search(
     :return list[DocumentResponse]: A list of matching documents.
     """
     search = []
-    if "q" in query_params.keys():
-        term = f"%{escape_like(query_params['q'])}%"
+    if "q" in search_params.keys():
+        term = f"%{escape_like(search_params['q'])}%"
         search.append(PhysicalDocument.title.ilike(term))
 
     condition = and_(*search) if len(search) > 1 else search[0]
@@ -219,7 +219,7 @@ def search(
             query = query.filter(Organisation.id == org_id)
         result = (
             query.order_by(desc(FamilyDocument.last_modified))
-            .limit(query_params["max_results"])
+            .limit(search_params["max_results"])
             .all()
         )
     except OperationalError as e:

--- a/app/repository/event.py
+++ b/app/repository/event.py
@@ -122,13 +122,13 @@ def get(db: Session, import_id: str) -> Optional[EventReadDTO]:
 
 
 def search(
-    db: Session, query_params: dict[str, Union[str, int]], org_id: Optional[int]
+    db: Session, search_params: dict[str, Union[str, int]], org_id: Optional[int]
 ) -> list[EventReadDTO]:
     """
     Get family events matching a search term on the event title or type.
 
     :param db Session: The database connection.
-    :param dict query_params: Any search terms to filter on specified
+    :param dict search_params: Any search terms to filter on specified
         fields (title & event type name by default if 'q' specified).
     :param org_id Optional[int]: the ID of the organisation the user belongs to
     :raises HTTPException: If a DB error occurs a 503 is returned.
@@ -137,8 +137,8 @@ def search(
     :return list[EventReadDTO]: A list of matching family events.
     """
     search = []
-    if "q" in query_params.keys():
-        term = f"%{escape_like(query_params['q'])}%"
+    if "q" in search_params.keys():
+        term = f"%{escape_like(search_params['q'])}%"
         search.append(
             or_(FamilyEvent.title.ilike(term), FamilyEvent.event_type_name.ilike(term))
         )
@@ -148,7 +148,7 @@ def search(
         query = _get_query(db).filter(condition)
         if org_id is not None:
             query = query.filter(Organisation.id == org_id)
-        found = query.limit(query_params["max_results"]).all()
+        found = query.limit(search_params["max_results"]).all()
     except OperationalError as e:
         if "canceling statement due to statement timeout" in str(e):
             raise TimeoutError

--- a/app/repository/protocols.py
+++ b/app/repository/protocols.py
@@ -28,7 +28,7 @@ class FamilyRepo(Protocol):
 
     @staticmethod
     def search(
-        db: Session, query_params: dict[str, Union[str, int]], org_id: Optional[int]
+        db: Session, search_params: dict[str, Union[str, int]], org_id: Optional[int]
     ) -> list[FamilyReadDTO]:
         """Searches the families"""
         ...

--- a/app/service/collection.py
+++ b/app/service/collection.py
@@ -64,7 +64,7 @@ def all(user: UserContext) -> list[CollectionReadDTO]:
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def search(
-    query_params: dict[str, Union[str, int]], user: UserContext
+    search_params: dict[str, Union[str, int]], user: UserContext
 ) -> list[CollectionReadDTO]:
     """
     Searches for the search term against collections on specified fields.
@@ -73,7 +73,7 @@ def search(
     descriptions of all the collections are searched for the given term
     only.
 
-    :param dict query_params: Search patterns to match against specified
+    :param dict search_params: Search patterns to match against specified
         fields, given as key value pairs in a dictionary.
     :param UserContext user: The current user context.
     :return list[CollectionReadDTO]: The list of collections matching
@@ -81,7 +81,7 @@ def search(
     """
     with db_session.get_db() as db:
         org_id = app_user.restrict_entities_to_user_org(user)
-        return collection_repo.search(db, query_params, org_id)
+        return collection_repo.search(db, search_params, org_id)
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/app/service/document.py
+++ b/app/service/document.py
@@ -62,7 +62,7 @@ def all(user: UserContext) -> list[DocumentReadDTO]:
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def search(
-    query_params: dict[str, Union[str, int]], user: UserContext
+    search_params: dict[str, Union[str, int]], user: UserContext
 ) -> list[DocumentReadDTO]:
     """
     Searches for the search term against documents on specified fields.
@@ -70,7 +70,7 @@ def search(
     Where 'q' is used instead of an explicit field name, only the titles
     of all the documents are searched for the given term.
 
-    :param dict query_params: Search patterns to match against specified
+    :param dict search_params: Search patterns to match against specified
         fields, given as key value pairs in a dictionary.
     :param UserContext user: The current user context.
     :return list[DocumentReadDTO]: The list of documents matching the
@@ -78,7 +78,7 @@ def search(
     """
     with db_session.get_db() as db:
         org_id = app_user.restrict_entities_to_user_org(user)
-        return document_repo.search(db, query_params, org_id)
+        return document_repo.search(db, search_params, org_id)
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/app/service/event.py
+++ b/app/service/event.py
@@ -51,7 +51,7 @@ def all(user: UserContext) -> list[EventReadDTO]:
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def search(
-    query_params: dict[str, Union[str, int]], user: UserContext
+    search_params: dict[str, Union[str, int]], user: UserContext
 ) -> list[EventReadDTO]:
     """
     Searches for the search term against events on specified fields.
@@ -60,7 +60,7 @@ def search(
     event type names of all the events are searched for the given term
     only.
 
-    :param dict query_params: Search patterns to match against specified
+    :param dict search_params: Search patterns to match against specified
         fields, given as key value pairs in a dictionary.
     :param UserContext user: The current user context.
     :return list[EventReadDTO]: The list of events matching the given
@@ -68,7 +68,7 @@ def search(
     """
     with db_session.get_db() as db:
         org_id = app_user.restrict_entities_to_user_org(user)
-        return event_repo.search(db, query_params, org_id)
+        return event_repo.search(db, search_params, org_id)
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -64,7 +64,7 @@ def all(user: UserContext) -> list[FamilyReadDTO]:
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def search(
-    query_params: dict[str, Union[str, int]], user: UserContext
+    search_params: dict[str, Union[str, int]], user: UserContext
 ) -> list[FamilyReadDTO]:
     """
     Searches for the search term against families on specified fields.
@@ -73,7 +73,7 @@ def search(
     descriptions of all the Families are searched for the given term
     only.
 
-    :param dict query_params: Search patterns to match against specified
+    :param dict search_params: Search patterns to match against specified
         fields, given as key value pairs in a dictionary.
     :param UserContext user: The current user context.
     :return list[FamilyDTO]: The list of families matching the given
@@ -81,7 +81,7 @@ def search(
     """
     with db_session.get_db() as db:
         org_id = app_user.restrict_entities_to_user_org(user)
-        return family_repo.search(db, query_params, org_id)
+        return family_repo.search(db, search_params, org_id)
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/tests/mocks/repos/family_repo.py
+++ b/tests/mocks/repos/family_repo.py
@@ -35,13 +35,13 @@ def get(db: Session, import_id: str) -> Optional[FamilyReadDTO]:
 
 
 def search(
-    db: Session, query_params: dict[str, Union[str, int]], org_id: Optional[int]
+    db: Session, search_params: dict[str, Union[str, int]], org_id: Optional[int]
 ) -> list[FamilyReadDTO]:
     _maybe_throw()
     _maybe_timeout()
     if family_repo.return_empty:
         return []
-    if "title" in query_params.keys():
+    if "title" in search_params.keys():
         return [create_family_read_dto("search1", collections=["x.y.z.1", "x.y.z.2"])]
     return [
         create_family_read_dto("search1", collections=["x.y.z.1", "x.y.z.2"]),


### PR DESCRIPTION
# Description

Rename 'query_params' to 'search_params' in service & repo layer [PDCT-1147](https://linear.app/climate-policy-radar/issue/PDCT-1147/remove-the-use-of-query-params-from-apprepositorydocumentpy)

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
