### PR TITLE
Give import_id a default value of None on the FamilyCreateDTO

### DIFF
--- a/app/model/family.py
+++ b/app/model/family.py
@@ -57,7 +57,7 @@ class FamilyCreateDTO(BaseModel):
      - organisation comes from the user's organisation
     """
 
-    import_id: Optional[str]
+    import_id: Optional[str] = None
     title: str
     summary: str
     geography: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.13.1"
+version = "2.13.2"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/helpers/family.py
+++ b/tests/helpers/family.py
@@ -73,7 +73,6 @@ def create_family_create_dto(
     if collections is None:
         collections = []
     return FamilyCreateDTO(
-        import_id="",
         title=title,
         summary=summary,
         geography=geography,


### PR DESCRIPTION
# Description
- fixes production bug where a family cannot be created because the import_id is required
- gives the import_id on the FamilyCreateDTO a default value of None

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
