### PR TITLE
Feature/pdct 1351 ingest documents

### DIFF
--- a/app/api/api_v1/routers/ingest.py
+++ b/app/api/api_v1/routers/ingest.py
@@ -143,7 +143,7 @@ async def ingest(new_data: UploadFile, corpus_import_id: str) -> Json:
     except RepositoryError as e:
         _LOGGER.error(e.message)
         raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e.message)
         )
     except HTTPException as e:
         _LOGGER.error(e)

--- a/app/model/document.py
+++ b/app/model/document.py
@@ -46,7 +46,7 @@ class DocumentWriteDTO(BaseModel):
 class DocumentCreateDTO(BaseModel):
     """Representation of a Document."""
 
-    import_id: Optional[str]
+    import_id: Optional[str] = None
     # From FamilyDocument
     family_import_id: str
     variant_name: Optional[str] = None

--- a/app/model/document.py
+++ b/app/model/document.py
@@ -46,6 +46,7 @@ class DocumentWriteDTO(BaseModel):
 class DocumentCreateDTO(BaseModel):
     """Representation of a Document."""
 
+    import_id: Optional[str]
     # From FamilyDocument
     family_import_id: str
     variant_name: Optional[str] = None

--- a/app/model/ingest.py
+++ b/app/model/ingest.py
@@ -81,7 +81,7 @@ class IngestDocumentDTO(BaseModel):
     source_url: Optional[AnyHttpUrl] = None
     user_language_name: Optional[str]
 
-    def to_document_create_dto(self) -> DocumentCreateDTO:
+    def to_document_create_dto(self, family_import_id) -> DocumentCreateDTO:
         """
         Convert IngestDocumentDTO to DocumentCreateDTO.
 
@@ -90,7 +90,7 @@ class IngestDocumentDTO(BaseModel):
 
         return DocumentCreateDTO(
             import_id=self.import_id,
-            family_import_id="",
+            family_import_id=family_import_id,
             variant_name=self.variant_name,
             metadata=self.metadata,
             title=self.title,

--- a/app/model/ingest.py
+++ b/app/model/ingest.py
@@ -4,6 +4,7 @@ from typing import Optional
 from pydantic import AnyHttpUrl, BaseModel
 
 from app.model.collection import CollectionCreateDTO
+from app.model.document import DocumentCreateDTO
 from app.model.family import FamilyCreateDTO
 from app.model.general import Json
 
@@ -79,3 +80,20 @@ class IngestDocumentDTO(BaseModel):
     title: str
     source_url: Optional[AnyHttpUrl] = None
     user_language_name: Optional[str]
+
+    def to_document_create_dto(self) -> DocumentCreateDTO:
+        """
+        Convert IngestDocumentDTO to DocumentCreateDTO.
+
+        :return DocumentCreateDTO: Converted DocumentCreateDTO instance.
+        """
+
+        return DocumentCreateDTO(
+            import_id=self.import_id,
+            family_import_id="",
+            variant_name=self.variant_name,
+            metadata=self.metadata,
+            title=self.title,
+            source_url=self.source_url,
+            user_language_name=self.user_language_name,
+        )

--- a/app/repository/collection.py
+++ b/app/repository/collection.py
@@ -219,7 +219,8 @@ def create(db: Session, collection: CollectionCreateDTO, org_id: int) -> str:
     :param db Session: the database connection
     :param CollectionDTO collection: the values for the new collection
     :param int org_id: a validated organisation id
-    :return bool: True if new collection was created otherwise false.
+    :raises RepositoryError: If a collection could not be created
+    :return str: import id of new collection
     """
     try:
         new_collection, collection_organisation = _collection_org_from_dto(

--- a/app/repository/collection.py
+++ b/app/repository/collection.py
@@ -43,7 +43,7 @@ def _collection_org_from_dto(
 ) -> Tuple[Collection, CollectionOrganisation]:
     return (
         Collection(
-            import_id=dto.import_id if dto.import_id else "",
+            import_id=dto.import_id if dto.import_id else None,
             title=dto.title,
             description=dto.description,
         ),

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -102,6 +102,7 @@ def _get_query(db: Session) -> Query:
 
 def _dto_to_family_document_dict(dto: DocumentCreateDTO) -> dict:
     return {
+        "import_id": dto.import_id if dto.import_id else "",
         "family_import_id": dto.family_import_id,
         "physical_document_id": 0,
         "variant_name": dto.variant_name,
@@ -412,9 +413,10 @@ def create(db: Session, document: DocumentCreateDTO) -> str:
 
         org_name = cast(str, org.name)
 
-        family_doc.import_id = cast(
-            Column, generate_import_id(db, CountedEntity.Document, org_name)
-        )
+        if not family_doc.import_id:
+            family_doc.import_id = cast(
+                Column, generate_import_id(db, CountedEntity.Document, org_name)
+            )
 
         # Add the new document and its language link
         db.add(family_doc)

--- a/app/repository/document.py
+++ b/app/repository/document.py
@@ -102,7 +102,7 @@ def _get_query(db: Session) -> Query:
 
 def _dto_to_family_document_dict(dto: DocumentCreateDTO) -> dict:
     return {
-        "import_id": dto.import_id if dto.import_id else "",
+        "import_id": dto.import_id if dto.import_id else None,
         "family_import_id": dto.family_import_id,
         "physical_document_id": 0,
         "variant_name": dto.variant_name,

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -112,6 +112,7 @@ def import_data(data: dict, corpus_import_id: str) -> dict:
             )
         if family_data:
             response["families"] = _save_families(db, family_data, corpus_import_id)
+        response["documents"] = ["test.new.document.0"]
 
         return response
     except Exception as e:

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -112,10 +112,6 @@ def save_documents(
     document_import_ids = []
     for doc in document_data:
         family_import_id = family_document_mapping[doc["import_id"]]
-        # if not family_import_id:
-        #     raise ValidationError(
-        #         f"No family associated with document: {doc['import_id']}"
-        #     )
 
         dto = IngestDocumentDTO(**doc).to_document_create_dto(family_import_id)
 

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -113,6 +113,23 @@ def _save_documents(
     return document_import_ids
 
 
+def validate_entity_relationships(data: dict) -> None:
+    family_documents = []
+    if "families" in data:
+        for fam in data["families"]:
+            family_documents.append(fam["documents"])
+
+    documents = []
+    if "documents" in data:
+        for doc in data["documents"]:
+            documents.append(doc["import_id"])
+
+    family_document_set = set(family_documents)
+    unmatched = [x for x in documents if x not in family_document_set]
+    if unmatched:
+        raise ValidationError(f"No family found for document(s): {unmatched}")
+
+
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def import_data(data: dict, corpus_import_id: str) -> dict:
     """

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -17,7 +17,7 @@ import app.service.collection as collection
 import app.service.corpus as corpus
 import app.service.geography as geography
 import app.service.metadata as metadata
-from app.model.ingest import IngestCollectionDTO, IngestFamilyDTO
+from app.model.ingest import IngestCollectionDTO, IngestDocumentDTO, IngestFamilyDTO
 from app.service.collection import validate_import_id
 
 
@@ -99,6 +99,7 @@ def import_data(data: dict, corpus_import_id: str) -> dict:
 
     collection_data = data["collections"] if "collections" in data else None
     family_data = data["families"] if "families" in data else None
+    document_data = data["documents"]
 
     if not data:
         raise HTTPException(status_code=status.HTTP_204_NO_CONTENT)
@@ -112,7 +113,15 @@ def import_data(data: dict, corpus_import_id: str) -> dict:
             )
         if family_data:
             response["families"] = _save_families(db, family_data, corpus_import_id)
-        response["documents"] = ["test.new.document.0"]
+
+        document_import_ids = []
+        # org_id = corpus.get_corpus_org_id(corpus_import_id)
+        for doc in document_data:
+            dto = IngestDocumentDTO(
+                **doc,
+            ).to_document_create_dto()
+            document_import_ids.append(dto.import_id)
+        response["documents"] = document_import_ids
 
         return response
     except Exception as e:

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -17,6 +17,7 @@ import app.service.collection as collection
 import app.service.corpus as corpus
 import app.service.geography as geography
 import app.service.metadata as metadata
+from app.errors import ValidationError
 from app.model.ingest import IngestCollectionDTO, IngestDocumentDTO, IngestFamilyDTO
 from app.service.collection import validate_import_id
 
@@ -95,6 +96,10 @@ def _save_documents(db: Session, document_data: list[dict]) -> list[str]:
         dto = IngestDocumentDTO(
             **doc,
         ).to_document_create_dto()
+
+        if dto.variant_name == "":
+            raise ValidationError("Variant name is empty")
+
         document_import_ids.append(dto.import_id)
     return document_import_ids
 

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -99,7 +99,7 @@ def import_data(data: dict, corpus_import_id: str) -> dict:
 
     collection_data = data["collections"] if "collections" in data else None
     family_data = data["families"] if "families" in data else None
-    document_data = data["documents"]
+    document_data = data["documents"] if "documents" in data else None
 
     if not data:
         raise HTTPException(status_code=status.HTTP_204_NO_CONTENT)
@@ -114,14 +114,15 @@ def import_data(data: dict, corpus_import_id: str) -> dict:
         if family_data:
             response["families"] = _save_families(db, family_data, corpus_import_id)
 
-        document_import_ids = []
-        # org_id = corpus.get_corpus_org_id(corpus_import_id)
-        for doc in document_data:
-            dto = IngestDocumentDTO(
-                **doc,
-            ).to_document_create_dto()
-            document_import_ids.append(dto.import_id)
-        response["documents"] = document_import_ids
+        if document_data:
+            document_import_ids = []
+            # org_id = corpus.get_corpus_org_id(corpus_import_id)
+            for doc in document_data:
+                dto = IngestDocumentDTO(
+                    **doc,
+                ).to_document_create_dto()
+                document_import_ids.append(dto.import_id)
+            response["documents"] = document_import_ids
 
         return response
     except Exception as e:

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 import app.clients.db.session as db_session
 import app.repository.collection as collection_repository
+import app.repository.document as document_repository
 import app.repository.family as family_repository
 import app.service.category as category
 import app.service.collection as collection
@@ -123,8 +124,8 @@ def save_documents(
             dto.metadata,
             EntitySpecificTaxonomyKeys.DOCUMENT.value,
         )
-
-        document_import_ids.append(dto.import_id)
+        import_id = document_repository.create(db, dto)
+        document_import_ids.append(import_id)
     return document_import_ids
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.13.4"
+version = "2.13.5"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.13.5"
+version = "2.14.0"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/helpers/document.py
+++ b/tests/helpers/document.py
@@ -23,7 +23,6 @@ def create_document_create_dto(
     return DocumentCreateDTO(
         family_import_id=family_import_id,
         variant_name=variant_name,
-        type="Law",
         metadata=metadata,
         title=title,
         source_url=source_url,
@@ -43,7 +42,6 @@ def create_document_write_dto(
         metadata = {"role": ["MAIN"], "type": ["Law"]}
     return DocumentWriteDTO(
         variant_name=variant_name,
-        type="Law",
         metadata=metadata,
         title=title,
         source_url=(
@@ -73,7 +71,6 @@ def create_document_read_dto(
         corpus_type=corpus_type,
         variant_name=variant_name,
         status=DocumentStatus.CREATED,
-        type="Law",
         metadata=metadata,
         slug="",
         physical_id=1,

--- a/tests/integration_tests/ingest/test.json
+++ b/tests/integration_tests/ingest/test.json
@@ -24,7 +24,7 @@
       },
       "collections": ["test.new.collection.0"],
       "events": [],
-      "documents": []
+      "documents": ["test.new.document.0", "test.new.document.1"]
     },
     {
       "import_id": "test.new.family.1",
@@ -39,6 +39,22 @@
       "collections": ["test.new.collection.1"],
       "events": [],
       "documents": []
+    }
+  ],
+  "documents": [
+    {
+      "import_id": "test.new.document.0",
+      "metadata": { "role": ["MAIN"], "type": ["Law"] },
+      "events": [],
+      "title": "",
+      "user_language_name": ""
+    },
+    {
+      "import_id": "test.new.document.1",
+      "metadata": { "role": ["MAIN"], "type": ["Law"] },
+      "events": [],
+      "title": "",
+      "user_language_name": ""
     }
   ]
 }

--- a/tests/integration_tests/ingest/test_ingest.py
+++ b/tests/integration_tests/ingest/test_ingest.py
@@ -6,26 +6,7 @@ from sqlalchemy.orm import Session
 from tests.integration_tests.setup_db import setup_db
 
 
-def test_ingest_when_corpus_import_id_invalid(
-    data_db: Session, client: TestClient, user_header_token
-):
-    invalid_corpus = "test"
-    response = client.post(
-        f"/api/v1/ingest/{invalid_corpus}",
-        files={"new_data": open("tests/integration_tests/ingest/test.json", "rb")},
-        headers=user_header_token,
-    )
-
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert (
-        response.json().get("detail")
-        == f"No organisation associated with corpus {invalid_corpus}"
-    )
-
-
-def test_ingest_collections_when_ok(
-    data_db: Session, client: TestClient, user_header_token
-):
+def test_ingest_when_ok(data_db: Session, client: TestClient, user_header_token):
 
     response = client.post(
         "/api/v1/ingest/UNFCCC.corpus.i00000001.n0000",
@@ -58,3 +39,20 @@ def test_ingest_rollback(
         .one_or_none()
     )
     assert actual_collection is None
+
+
+def test_ingest_when_corpus_import_id_invalid(
+    data_db: Session, client: TestClient, user_header_token
+):
+    invalid_corpus = "test"
+    response = client.post(
+        f"/api/v1/ingest/{invalid_corpus}",
+        files={"new_data": open("tests/integration_tests/ingest/test.json", "rb")},
+        headers=user_header_token,
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert (
+        response.json().get("detail")
+        == f"No organisation associated with corpus {invalid_corpus}"
+    )

--- a/tests/integration_tests/ingest/test_ingest.py
+++ b/tests/integration_tests/ingest/test_ingest.py
@@ -32,7 +32,7 @@ def test_ingest_when_ok(data_db: Session, client: TestClient, user_header_token)
         .all()
     )
 
-    assert saved_collections
+    assert len(saved_collections) == 2
     for coll in saved_collections:
         assert coll.import_id in expected_collection_import_ids
 
@@ -42,7 +42,7 @@ def test_ingest_when_ok(data_db: Session, client: TestClient, user_header_token)
         .all()
     )
 
-    assert saved_families
+    assert len(saved_families) == 2
     for fam in saved_families:
         assert fam.import_id in expected_family_import_ids
 
@@ -52,7 +52,7 @@ def test_ingest_when_ok(data_db: Session, client: TestClient, user_header_token)
         .all()
     )
 
-    assert saved_documents
+    assert len(saved_documents) == 2
     for doc in saved_documents:
         assert doc.import_id in expected_document_import_ids
         assert doc.family_import_id in expected_family_import_ids

--- a/tests/unit_tests/routers/ingest/test.json
+++ b/tests/unit_tests/routers/ingest/test.json
@@ -38,7 +38,25 @@
       },
       "collections": ["test.new.collection.1"],
       "events": [],
-      "documents": []
+      "documents": ["test.new.document.0"]
+    }
+  ],
+  "documents": [
+    {
+      "import_id": "test.new.document.0",
+      "variant_name": "",
+      "metadata": {},
+      "events": [],
+      "title": "",
+      "user_language_name": ""
+    },
+    {
+      "import_id": "test.new.document.1",
+      "variant_name": "",
+      "metadata": {},
+      "events": [],
+      "title": "",
+      "user_language_name": ""
     }
   ]
 }

--- a/tests/unit_tests/routers/ingest/test.json
+++ b/tests/unit_tests/routers/ingest/test.json
@@ -24,7 +24,7 @@
       },
       "collections": ["test.new.collection.0"],
       "events": [],
-      "documents": []
+      "documents": ["test.new.document.0", "test.new.document.1"]
     },
     {
       "import_id": "test.new.family.1",
@@ -44,16 +44,14 @@
   "documents": [
     {
       "import_id": "test.new.document.0",
-      "variant_name": "",
-      "metadata": {},
+      "metadata": { "color": ["pink"] },
       "events": [],
       "title": "",
       "user_language_name": ""
     },
     {
       "import_id": "test.new.document.1",
-      "variant_name": "",
-      "metadata": {},
+      "metadata": { "color": ["pink"] },
       "events": [],
       "title": "",
       "user_language_name": ""

--- a/tests/unit_tests/routers/ingest/test_ingest.py
+++ b/tests/unit_tests/routers/ingest/test_ingest.py
@@ -4,6 +4,9 @@ Tests the route for bulk import of data.
 This uses service mocks and ensures the endpoint calls into each service.
 """
 
+import io
+import json
+
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -39,48 +42,48 @@ def test_ingest_data_when_ok(
     }
 
 
-# def test_ingest_when_data_invalid(
-#     client: TestClient, user_header_token, corpus_service_mock
-# ):
+def test_ingest_when_data_invalid(
+    client: TestClient, user_header_token, corpus_service_mock
+):
 
-#     invalid_import_id = "invalid"
-#     test_data = json.dumps(
-#         {
-#             "collections": [
-#                 {
-#                     "import_id": invalid_import_id,
-#                     "title": "Test title",
-#                     "description": "Test description",
-#                 },
-#             ],
-#         }
-#     ).encode("utf-8")
-#     test_data_file = io.BytesIO(test_data)
+    invalid_import_id = "invalid"
+    test_data = json.dumps(
+        {
+            "collections": [
+                {
+                    "import_id": invalid_import_id,
+                    "title": "Test title",
+                    "description": "Test description",
+                },
+            ],
+        }
+    ).encode("utf-8")
+    test_data_file = io.BytesIO(test_data)
 
-#     response = client.post(
-#         "/api/v1/ingest/test",
-#         files={"new_data": test_data_file},
-#         headers=user_header_token,
-#     )
+    response = client.post(
+        "/api/v1/ingest/test",
+        files={"new_data": test_data_file},
+        headers=user_header_token,
+    )
 
-#     assert response.status_code == status.HTTP_400_BAD_REQUEST
-#     assert response.json().get("detail") == "The import id invalid is invalid!"
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json().get("detail") == "The import id invalid is invalid!"
 
 
-# def test_ingest_when_no_data(
-#     client: TestClient, user_header_token, collection_repo_mock, corpus_service_mock
-# ):
-#     test_data = json.dumps({}).encode("utf-8")
-#     test_data_file = io.BytesIO(test_data)
-#     response = client.post(
-#         "/api/v1/ingest/test",
-#         files={"new_data": test_data_file},
-#         headers=user_header_token,
-#     )
+def test_ingest_when_no_data(
+    client: TestClient, user_header_token, collection_repo_mock, corpus_service_mock
+):
+    test_data = json.dumps({}).encode("utf-8")
+    test_data_file = io.BytesIO(test_data)
+    response = client.post(
+        "/api/v1/ingest/test",
+        files={"new_data": test_data_file},
+        headers=user_header_token,
+    )
 
-#     assert collection_repo_mock.create.call_count == 0
+    assert collection_repo_mock.create.call_count == 0
 
-#     assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
 def test_ingest_data_when_db_error(

--- a/tests/unit_tests/routers/ingest/test_ingest.py
+++ b/tests/unit_tests/routers/ingest/test_ingest.py
@@ -4,9 +4,6 @@ Tests the route for bulk import of data.
 This uses service mocks and ensures the endpoint calls into each service.
 """
 
-import io
-import json
-
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -38,51 +35,52 @@ def test_ingest_data_when_ok(
     assert response.json() == {
         "collections": ["test.new.collection.0", "test.new.collection.0"],
         "families": ["created", "created"],
+        "documents": ["test.new.document.0", "test.new.document.1"],
     }
 
 
-def test_ingest_when_data_invalid(
-    client: TestClient, user_header_token, corpus_service_mock
-):
+# def test_ingest_when_data_invalid(
+#     client: TestClient, user_header_token, corpus_service_mock
+# ):
 
-    invalid_import_id = "invalid"
-    test_data = json.dumps(
-        {
-            "collections": [
-                {
-                    "import_id": invalid_import_id,
-                    "title": "Test title",
-                    "description": "Test description",
-                },
-            ],
-        }
-    ).encode("utf-8")
-    test_data_file = io.BytesIO(test_data)
+#     invalid_import_id = "invalid"
+#     test_data = json.dumps(
+#         {
+#             "collections": [
+#                 {
+#                     "import_id": invalid_import_id,
+#                     "title": "Test title",
+#                     "description": "Test description",
+#                 },
+#             ],
+#         }
+#     ).encode("utf-8")
+#     test_data_file = io.BytesIO(test_data)
 
-    response = client.post(
-        "/api/v1/ingest/test",
-        files={"new_data": test_data_file},
-        headers=user_header_token,
-    )
+#     response = client.post(
+#         "/api/v1/ingest/test",
+#         files={"new_data": test_data_file},
+#         headers=user_header_token,
+#     )
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json().get("detail") == "The import id invalid is invalid!"
+#     assert response.status_code == status.HTTP_400_BAD_REQUEST
+#     assert response.json().get("detail") == "The import id invalid is invalid!"
 
 
-def test_ingest_when_no_data(
-    client: TestClient, user_header_token, collection_repo_mock, corpus_service_mock
-):
-    test_data = json.dumps({}).encode("utf-8")
-    test_data_file = io.BytesIO(test_data)
-    response = client.post(
-        "/api/v1/ingest/test",
-        files={"new_data": test_data_file},
-        headers=user_header_token,
-    )
+# def test_ingest_when_no_data(
+#     client: TestClient, user_header_token, collection_repo_mock, corpus_service_mock
+# ):
+#     test_data = json.dumps({}).encode("utf-8")
+#     test_data_file = io.BytesIO(test_data)
+#     response = client.post(
+#         "/api/v1/ingest/test",
+#         files={"new_data": test_data_file},
+#         headers=user_header_token,
+#     )
 
-    assert collection_repo_mock.create.call_count == 0
+#     assert collection_repo_mock.create.call_count == 0
 
-    assert response.status_code == status.HTTP_204_NO_CONTENT
+#     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
 def test_ingest_data_when_db_error(

--- a/tests/unit_tests/routers/ingest/test_ingest.py
+++ b/tests/unit_tests/routers/ingest/test_ingest.py
@@ -25,6 +25,7 @@ def test_ingest_data_when_ok(
     geography_repo_mock,
     corpus_repo_mock,
     family_repo_mock,
+    document_repo_mock,
     db_client_metadata_mock,
 ):
 
@@ -38,7 +39,7 @@ def test_ingest_data_when_ok(
     assert response.json() == {
         "collections": ["test.new.collection.0", "test.new.collection.0"],
         "families": ["created", "created"],
-        "documents": ["test.new.document.0", "test.new.document.1"],
+        "documents": ["test.new.doc.0", "test.new.doc.0"],
     }
 
 

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -10,6 +10,7 @@ def test_ingest_when_ok(
     db_client_metadata_mock,
     collection_repo_mock,
     family_repo_mock,
+    document_repo_mock,
 ):
     test_data = {
         "collections": [
@@ -48,7 +49,7 @@ def test_ingest_when_ok(
     assert ingest_service.import_data(test_data, "test") == {
         "collections": ["test.new.collection.0"],
         "families": ["created"],
-        "documents": ["test.new.document.0"],
+        "documents": ["test.new.doc.0"],
     }
 
 

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -35,7 +35,7 @@ def test_ingest_when_ok(
         "documents": [
             {
                 "import_id": "test.new.document.0",
-                "variant_name": "",
+                "variant_name": "Original Language",
                 "metadata": {},
                 "events": [],
                 "title": "",
@@ -282,3 +282,23 @@ def test_ingest_families_when_metadata_invalid(
         ingest_service.import_data(test_data, "test")
     expected_msg = "Metadata validation failed: Missing metadata keys:"
     assert expected_msg in e.value.message
+
+
+def test_ingest_documents_when_variant_empty(
+    corpus_repo_mock, geography_repo_mock, collection_repo_mock, db_client_metadata_mock
+):
+    test_data = {
+        "documents": [
+            {
+                "import_id": "test.new.document.0",
+                "variant_name": "",
+                "metadata": {},
+                "events": [],
+                "title": "",
+                "user_language_name": "",
+            },
+        ],
+    }
+    with pytest.raises(ValidationError) as e:
+        ingest_service.import_data(test_data, "test")
+    assert e.value.message == "Variant name is empty"

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -34,7 +34,7 @@ def test_ingest_when_ok(
         ],
         "documents": [
             {
-                "import_id": "",
+                "import_id": "test.new.document.0",
                 "variant_name": "",
                 "metadata": {},
                 "events": [],

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -284,9 +284,7 @@ def test_ingest_families_when_metadata_invalid(
     assert expected_msg in e.value.message
 
 
-def test_ingest_documents_when_variant_empty(
-    corpus_repo_mock, geography_repo_mock, collection_repo_mock, db_client_metadata_mock
-):
+def test_ingest_documents_when_variant_empty():
     test_data = {
         "documents": [
             {
@@ -304,9 +302,7 @@ def test_ingest_documents_when_variant_empty(
     assert e.value.message == "Variant name is empty"
 
 
-def test_ingest_documents_when_metadata_invalid(
-    corpus_repo_mock, geography_repo_mock, collection_repo_mock, db_client_metadata_mock
-):
+def test_ingest_documents_when_metadata_invalid(db_client_metadata_mock):
     test_data = {
         "documents": [
             {
@@ -323,3 +319,29 @@ def test_ingest_documents_when_metadata_invalid(
         ingest_service.import_data(test_data, "test")
     expected_msg = "Metadata validation failed: Missing metadata keys:"
     assert expected_msg in e.value.message
+
+
+def test_validate_entity_relationships_when_no_family_matching_document():
+    doc_import_id = "test.new.document.0"
+    test_data = {"documents": [{"import_id": doc_import_id}]}
+    with pytest.raises(ValidationError) as e:
+        ingest_service.validate_entity_relationships(test_data)
+    assert e.value.message == f"No family found for document(s): ['{doc_import_id}']"
+
+
+# def test_ingest_documents_when_no_family(db_client_metadata_mock):
+#     test_data = {
+#         "documents": [
+#             {
+#                 "import_id": "test.new.document.0",
+#                 "variant_name": None,
+#                 "metadata": {"color": ["blue"]},
+#                 "events": [],
+#                 "title": "",
+#                 "user_language_name": "",
+#             },
+#         ],
+#     }
+#     with pytest.raises(ValidationError) as e:
+#         ingest_service.import_data(test_data, "test")
+#     assert e.value.message == "Could not find family for document: test.new.document.0"

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -36,7 +36,7 @@ def test_ingest_when_ok(
             {
                 "import_id": "test.new.document.0",
                 "variant_name": "Original Language",
-                "metadata": {},
+                "metadata": {"color": ["blue"]},
                 "events": [],
                 "title": "",
                 "source_url": None,
@@ -302,3 +302,24 @@ def test_ingest_documents_when_variant_empty(
     with pytest.raises(ValidationError) as e:
         ingest_service.import_data(test_data, "test")
     assert e.value.message == "Variant name is empty"
+
+
+def test_ingest_documents_when_metadata_invalid(
+    corpus_repo_mock, geography_repo_mock, collection_repo_mock, db_client_metadata_mock
+):
+    test_data = {
+        "documents": [
+            {
+                "import_id": "test.new.document.0",
+                "variant_name": None,
+                "metadata": {},
+                "events": [],
+                "title": "",
+                "user_language_name": "",
+            },
+        ],
+    }
+    with pytest.raises(ValidationError) as e:
+        ingest_service.import_data(test_data, "test")
+    expected_msg = "Metadata validation failed: Missing metadata keys:"
+    assert expected_msg in e.value.message

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -21,7 +21,7 @@ def test_ingest_when_ok(
         ],
         "families": [
             {
-                "import_id": "",
+                "import_id": "test.new.family.0",
                 "title": "Test",
                 "summary": "Test",
                 "geography": "Test",
@@ -287,7 +287,9 @@ def test_save_documents_when_variant_empty():
     ]
 
     with pytest.raises(ValidationError) as e:
-        ingest_service.save_documents(test_data, "test")
+        ingest_service.save_documents(
+            test_data, "test", {"test.new.document.0": "test.new.family.0"}
+        )
     assert e.value.message == "Variant name is empty"
 
 
@@ -304,7 +306,9 @@ def test_ingest_documents_when_metadata_invalid(db_client_metadata_mock):
     ]
 
     with pytest.raises(ValidationError) as e:
-        ingest_service.save_documents(test_data, "test")
+        ingest_service.save_documents(
+            test_data, "test", {"test.new.document.0": "test.new.family.0"}
+        )
     expected_msg = "Metadata validation failed: Missing metadata keys:"
     assert expected_msg in e.value.message
 

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -29,7 +29,7 @@ def test_ingest_when_ok(
                 "metadata": {"color": ["blue"], "size": [""]},
                 "collections": [],
                 "events": [],
-                "documents": [],
+                "documents": ["test.new.document.0"],
             },
         ],
         "documents": [
@@ -70,20 +70,18 @@ def test_ingest_when_db_error(corpus_repo_mock, collection_repo_mock):
     assert e.value.message == "bad collection repo"
 
 
-def test_ingest_collections_when_import_id_wrong_format(corpus_repo_mock):
+def test_save_collections_when_import_id_wrong_format(corpus_repo_mock):
     invalid_import_id = "invalid"
-    test_data = {
-        "collections": [
-            {
-                "import_id": invalid_import_id,
-                "title": "Test title",
-                "description": "Test description",
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": invalid_import_id,
+            "title": "Test title",
+            "description": "Test description",
+        },
+    ]
 
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_collections(test_data, "test")
     expected_msg = "The import id invalid is invalid!"
     assert e.value.message == expected_msg
 
@@ -92,69 +90,65 @@ def test_ingest_families_when_import_id_wrong_format(
     corpus_repo_mock, geography_repo_mock, db_client_metadata_mock
 ):
     invalid_import_id = "invalid"
-    test_data = {
-        "families": [
-            {
-                "import_id": invalid_import_id,
-                "title": "Test",
-                "summary": "Test",
-                "geography": "Test",
-                "category": "UNFCCC",
-                "metadata": {"color": ["blue"], "size": [""]},
-                "collections": [],
-                "events": [],
-                "documents": [],
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": invalid_import_id,
+            "title": "Test",
+            "summary": "Test",
+            "geography": "Test",
+            "category": "UNFCCC",
+            "metadata": {"color": ["blue"], "size": [""]},
+            "collections": [],
+            "events": [],
+            "documents": [],
+        },
+    ]
 
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_families(test_data, "test")
     expected_msg = "The import id invalid is invalid!"
     assert e.value.message == expected_msg
 
 
 def test_ingest_families_when_geography_invalid(corpus_repo_mock, geography_repo_mock):
     geography_repo_mock.error = True
-    test_data = {
-        "families": [
-            {
-                "import_id": "test.new.family.0",
-                "title": "Test",
-                "summary": "Test",
-                "geography": "Invalid",
-                "category": "Test",
-                "metadata": {},
-                "collections": [],
-                "events": [],
-                "documents": [],
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": "test.new.family.0",
+            "title": "Test",
+            "summary": "Test",
+            "geography": "Invalid",
+            "category": "Test",
+            "metadata": {},
+            "collections": [],
+            "events": [],
+            "documents": [],
+        },
+    ]
+
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_families(test_data, "test")
     expected_msg = "The geography value Invalid is invalid!"
     assert e.value.message == expected_msg
 
 
 def test_ingest_families_when_category_invalid(corpus_repo_mock, geography_repo_mock):
-    test_data = {
-        "families": [
-            {
-                "import_id": "test.new.family.0",
-                "title": "Test",
-                "summary": "Test",
-                "geography": "Test",
-                "category": "Test",
-                "metadata": {},
-                "collections": [],
-                "events": [],
-                "documents": [],
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": "test.new.family.0",
+            "title": "Test",
+            "summary": "Test",
+            "geography": "Test",
+            "category": "Test",
+            "metadata": {},
+            "collections": [],
+            "events": [],
+            "documents": [],
+        },
+    ]
+
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_families(test_data, "test")
     expected_msg = "Test is not a valid FamilyCategory"
     assert e.value.message == expected_msg
 
@@ -162,23 +156,22 @@ def test_ingest_families_when_category_invalid(corpus_repo_mock, geography_repo_
 def test_ingest_families_when_corpus_invalid(corpus_repo_mock):
     corpus_repo_mock.valid = False
 
-    test_data = {
-        "families": [
-            {
-                "import_id": "test.new.family.0",
-                "title": "Test",
-                "summary": "Test",
-                "geography": "Test",
-                "category": "Test",
-                "metadata": {},
-                "collections": [],
-                "events": [],
-                "documents": [],
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": "test.new.family.0",
+            "title": "Test",
+            "summary": "Test",
+            "geography": "Test",
+            "category": "Test",
+            "metadata": {},
+            "collections": [],
+            "events": [],
+            "documents": [],
+        },
+    ]
+
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_families(test_data, "test")
     expected_msg = "Corpus 'test' not found"
     assert e.value.message == expected_msg
 
@@ -186,23 +179,22 @@ def test_ingest_families_when_corpus_invalid(corpus_repo_mock):
 def test_ingest_families_when_collection_ids_invalid(
     corpus_repo_mock, geography_repo_mock
 ):
-    test_data = {
-        "families": [
-            {
-                "import_id": "test.new.family.0",
-                "title": "Test",
-                "summary": "Test",
-                "geography": "Test",
-                "category": "UNFCCC",
-                "metadata": {},
-                "collections": ["invalid"],
-                "events": [],
-                "documents": [],
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": "test.new.family.0",
+            "title": "Test",
+            "summary": "Test",
+            "geography": "Test",
+            "category": "UNFCCC",
+            "metadata": {},
+            "collections": ["invalid"],
+            "events": [],
+            "documents": [],
+        },
+    ]
+
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_families(test_data, "test")
     expected_msg = "The import ids are invalid: ['invalid']"
     assert e.value.message == expected_msg
 
@@ -239,23 +231,22 @@ def test_ingest_families_when_metadata_not_found(
 ):
     db_client_metadata_mock.bad_taxonomy = True
 
-    test_data = {
-        "families": [
-            {
-                "import_id": "test.new.family.0",
-                "title": "Test",
-                "summary": "Test",
-                "geography": "Test",
-                "category": "UNFCCC",
-                "metadata": {},
-                "collections": ["id.does.not.exist"],
-                "events": [],
-                "documents": [],
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": "test.new.family.0",
+            "title": "Test",
+            "summary": "Test",
+            "geography": "Test",
+            "category": "UNFCCC",
+            "metadata": {},
+            "collections": ["id.does.not.exist"],
+            "events": [],
+            "documents": [],
+        },
+    ]
+
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_families(test_data, "test")
     expected_msg = "No taxonomy found for corpus"
     assert e.value.message == expected_msg
 
@@ -263,60 +254,57 @@ def test_ingest_families_when_metadata_not_found(
 def test_ingest_families_when_metadata_invalid(
     corpus_repo_mock, geography_repo_mock, collection_repo_mock, db_client_metadata_mock
 ):
-    test_data = {
-        "families": [
-            {
-                "import_id": "test.new.family.0",
-                "title": "Test",
-                "summary": "Test",
-                "geography": "Test",
-                "category": "UNFCCC",
-                "metadata": {},
-                "collections": ["id.does.not.exist"],
-                "events": [],
-                "documents": [],
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": "test.new.family.0",
+            "title": "Test",
+            "summary": "Test",
+            "geography": "Test",
+            "category": "UNFCCC",
+            "metadata": {},
+            "collections": ["id.does.not.exist"],
+            "events": [],
+            "documents": [],
+        },
+    ]
+
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_families(test_data, "test")
     expected_msg = "Metadata validation failed: Missing metadata keys:"
     assert expected_msg in e.value.message
 
 
-def test_ingest_documents_when_variant_empty():
-    test_data = {
-        "documents": [
-            {
-                "import_id": "test.new.document.0",
-                "variant_name": "",
-                "metadata": {},
-                "events": [],
-                "title": "",
-                "user_language_name": "",
-            },
-        ],
-    }
+def test_save_documents_when_variant_empty():
+    test_data = [
+        {
+            "import_id": "test.new.document.0",
+            "variant_name": "",
+            "metadata": {},
+            "events": [],
+            "title": "",
+            "user_language_name": "",
+        },
+    ]
+
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_documents(test_data, "test")
     assert e.value.message == "Variant name is empty"
 
 
 def test_ingest_documents_when_metadata_invalid(db_client_metadata_mock):
-    test_data = {
-        "documents": [
-            {
-                "import_id": "test.new.document.0",
-                "variant_name": None,
-                "metadata": {},
-                "events": [],
-                "title": "",
-                "user_language_name": "",
-            },
-        ],
-    }
+    test_data = [
+        {
+            "import_id": "test.new.document.0",
+            "variant_name": None,
+            "metadata": {},
+            "events": [],
+            "title": "",
+            "user_language_name": "",
+        },
+    ]
+
     with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
+        ingest_service.save_documents(test_data, "test")
     expected_msg = "Metadata validation failed: Missing metadata keys:"
     assert expected_msg in e.value.message
 
@@ -324,24 +312,16 @@ def test_ingest_documents_when_metadata_invalid(db_client_metadata_mock):
 def test_validate_entity_relationships_when_no_family_matching_document():
     doc_import_id = "test.new.document.0"
     test_data = {"documents": [{"import_id": doc_import_id}]}
+
     with pytest.raises(ValidationError) as e:
         ingest_service.validate_entity_relationships(test_data)
     assert e.value.message == f"No family found for document(s): ['{doc_import_id}']"
 
 
-# def test_ingest_documents_when_no_family(db_client_metadata_mock):
-#     test_data = {
-#         "documents": [
-#             {
-#                 "import_id": "test.new.document.0",
-#                 "variant_name": None,
-#                 "metadata": {"color": ["blue"]},
-#                 "events": [],
-#                 "title": "",
-#                 "user_language_name": "",
-#             },
-#         ],
-#     }
-#     with pytest.raises(ValidationError) as e:
-#         ingest_service.import_data(test_data, "test")
-#     assert e.value.message == "Could not find family for document: test.new.document.0"
+def test_ingest_documents_when_no_family():
+    doc_import_id = "test.new.document.0"
+    test_data = {"documents": [{"import_id": doc_import_id}]}
+
+    with pytest.raises(ValidationError) as e:
+        ingest_service.import_data(test_data, "test")
+    assert e.value.message == f"No family found for document(s): ['{doc_import_id}']"

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -32,11 +32,23 @@ def test_ingest_when_ok(
                 "documents": [],
             },
         ],
+        "documents": [
+            {
+                "import_id": "",
+                "variant_name": "",
+                "metadata": {},
+                "events": [],
+                "title": "",
+                "source_url": None,
+                "user_language_name": "",
+            }
+        ],
     }
 
     assert ingest_service.import_data(test_data, "test") == {
         "collections": ["test.new.collection.0"],
         "families": ["created"],
+        "documents": ["test.new.document.0"],
     }
 
 


### PR DESCRIPTION
# Description
- ingest documents from json passed to the ingest endpoint
- validate each document data before saving
- roll back db transaction on any error
- validate that all documents are linked to a family within the json before saving and throw an error if not
- make save_collections, save_families and save_documents not private so that they can be tested
- refactor some of the ingest service tests to be narrower

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
