### PR TITLE
Feature/pdct 1402 validate collection exists before creating family

### DIFF
--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -162,10 +162,17 @@ def validate_entity_relationships(data: dict[str, Any]) -> None:
     :param dict[str, Any] data: The data object containing entities to be validated.
     :raises ValidationError: raised should there be any unmatched relationships.
     """
+    collections = []
+    if "collections" in data:
+        for coll in data["collections"]:
+            collections.append(coll["import_id"])
+
     families = []
+    family_collection_import_ids = []
     if "families" in data:
         for fam in data["families"]:
             families.append(fam["import_id"])
+            family_collection_import_ids.extend(fam["collections"])
 
     document_family_import_ids = []
     if "documents" in data:
@@ -176,6 +183,11 @@ def validate_entity_relationships(data: dict[str, Any]) -> None:
     if "events" in data:
         for event in data["events"]:
             event_family_import_ids.append(event["family_import_id"])
+
+    collections_set = set(collections)
+    for fam_coll in family_collection_import_ids:
+        if fam_coll not in collections_set:
+            raise ValidationError(f"No collection with id {fam_coll} found for family")
 
     families_set = set(families)
     for doc_fam in document_family_import_ids:

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -5,6 +5,7 @@ This layer uses the corpus, collection, family, document and event repos to hand
 import of data and other services for validation etc.
 """
 
+from enum import Enum
 from typing import Any, Optional
 
 from fastapi import HTTPException, status
@@ -26,6 +27,15 @@ from app.model.ingest import (
     IngestEventDTO,
     IngestFamilyDTO,
 )
+
+
+class IngestEntityList(str, Enum):
+    """Name of the list of entities that can be ingested."""
+
+    Collections = "collections"
+    Families = "families"
+    Documents = "documents"
+    Events = "events"
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
@@ -154,49 +164,90 @@ def save_events(
     return event_import_ids
 
 
-def validate_entity_relationships(data: dict[str, Any]) -> None:
+def _collect_import_ids(
+    entity_list_name: IngestEntityList,
+    data: dict[str, Any],
+    import_id_type_name: Optional[str] = None,
+) -> list[str]:
     """
-    Validates relationships between entities contained in data based on import_ids.
-    For documents, it validates that the family the document is linked to exists.
+    Extracts a list of import_ids (or family_import_ids if specified) for the specified entity list in data.
+
+    :param IngestEntityList entity_list_name: The name of the entity list from which the import_ids are to be extracted.
+    :param dict[str, Any] data: The data structure containing the entity lists used for extraction.
+    :param Optional[str] import_id_type_name: the name of the type of import_id to be extracted or None.
+    :return list[str]: A list of extracted import_ids for the specified entity list.
+    """
+    import_id_key = import_id_type_name or "import_id"
+    import_ids = []
+    if entity_list_name.value in data:
+        for entity in data[entity_list_name.value]:
+            import_ids.append(entity[import_id_key])
+    return import_ids
+
+
+def _match_import_ids(
+    parent_references: list[str], parent_import_ids: set[str]
+) -> None:
+    """
+    Validates that all the references to parent entities exist in the set of parent import_ids passed in
+
+    :param list[str] parent_references: List of import_ids referencing parent entities to be validated.
+    :param set[str] parent_import_ids: Set of parent import_ids to validate against.
+    :raises ValidationError: raised if a parent reference is not found in the parent_import_ids.
+    """
+    for id in parent_references:
+        if id not in parent_import_ids:
+            raise ValidationError(f"No entity with id {id} found")
+
+
+def _validate_collections_exist_for_families(data: dict[str, Any]) -> None:
+    """
+    Validates that collections the families are linked to exist based on import_id links in data.
 
     :param dict[str, Any] data: The data object containing entities to be validated.
-    :raises ValidationError: raised should there be any unmatched relationships.
     """
-    collections = []
-    if "collections" in data:
-        for coll in data["collections"]:
-            collections.append(coll["import_id"])
+    collections = _collect_import_ids(IngestEntityList.Collections, data)
+    collections_set = set(collections)
 
-    families = []
     family_collection_import_ids = []
     if "families" in data:
         for fam in data["families"]:
-            families.append(fam["import_id"])
             family_collection_import_ids.extend(fam["collections"])
 
-    document_family_import_ids = []
-    if "documents" in data:
-        for entity in data["documents"]:
-            document_family_import_ids.append(entity["family_import_id"])
+    _match_import_ids(family_collection_import_ids, collections_set)
 
-    event_family_import_ids = []
-    if "events" in data:
-        for event in data["events"]:
-            event_family_import_ids.append(event["family_import_id"])
 
-    collections_set = set(collections)
-    for fam_coll in family_collection_import_ids:
-        if fam_coll not in collections_set:
-            raise ValidationError(f"No collection with id {fam_coll} found for family")
+def _validate_families_exist_for_events_and_documents(data: dict[str, Any]) -> None:
+    """
+    Validates that families the documents and events are linked to exist
+    based on import_id links in data.
 
+    :param dict[str, Any] data: The data object containing entities to be validated.
+    """
+    families = _collect_import_ids(IngestEntityList.Families, data)
     families_set = set(families)
-    for doc_fam in document_family_import_ids:
-        if doc_fam not in families_set:
-            raise ValidationError(f"No family with id {doc_fam} found for document")
 
-    for event_fam in event_family_import_ids:
-        if event_fam not in families_set:
-            raise ValidationError(f"No family with id {event_fam} found for event")
+    document_family_import_ids = _collect_import_ids(
+        IngestEntityList.Documents, data, "family_import_id"
+    )
+    event_family_import_ids = _collect_import_ids(
+        IngestEntityList.Events, data, "family_import_id"
+    )
+
+    _match_import_ids(document_family_import_ids, families_set)
+    _match_import_ids(event_family_import_ids, families_set)
+
+
+def validate_entity_relationships(data: dict[str, Any]) -> None:
+    """
+    Validates relationships between entities contained in data.
+    For documents, it validates that the family the document is linked to exists.
+
+    :param dict[str, Any] data: The data object containing entities to be validated.
+    """
+
+    _validate_collections_exist_for_families(data)
+    _validate_families_exist_for_events_and_documents(data)
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.15.2"
+version = "2.15.3"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -146,7 +146,7 @@ def test_validate_entity_relationships_when_no_family_matching_document():
 
     with pytest.raises(ValidationError) as e:
         ingest_service.validate_entity_relationships(test_data)
-    assert f"No family with id {fam_import_id} found for document" == e.value.message
+    assert f"No entity with id {fam_import_id} found" == e.value.message
 
 
 def test_validate_entity_relationships_when_no_family_matching_event():
@@ -157,7 +157,7 @@ def test_validate_entity_relationships_when_no_family_matching_event():
 
     with pytest.raises(ValidationError) as e:
         ingest_service.validate_entity_relationships(test_data)
-    assert f"No family with id {fam_import_id} found for event" == e.value.message
+    assert f"No entity with id {fam_import_id} found" == e.value.message
 
 
 def test_validate_entity_relationships_when_no_collection_matching_family():
@@ -168,7 +168,7 @@ def test_validate_entity_relationships_when_no_collection_matching_family():
 
     with pytest.raises(ValidationError) as e:
         ingest_service.validate_entity_relationships(test_data)
-    assert f"No collection with id {coll_import_id} found for family" == e.value.message
+    assert f"No entity with id {coll_import_id} found" == e.value.message
 
 
 def test_save_documents_when_no_family():
@@ -181,7 +181,7 @@ def test_save_documents_when_no_family():
 
     with pytest.raises(ValidationError) as e:
         ingest_service.import_data(test_data, "test")
-    assert f"No family with id {fam_import_id} found for document" == e.value.message
+    assert f"No entity with id {fam_import_id} found" == e.value.message
 
 
 def test_save_events_when_data_invalid(validation_service_mock):

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -160,6 +160,17 @@ def test_validate_entity_relationships_when_no_family_matching_event():
     assert f"No family with id {fam_import_id} found for event" == e.value.message
 
 
+def test_validate_entity_relationships_when_no_collection_matching_family():
+    coll_import_id = "test.new.collection.0"
+    test_data = {
+        "families": [{"import_id": "test.new.event.0", "collections": [coll_import_id]}]
+    }
+
+    with pytest.raises(ValidationError) as e:
+        ingest_service.validate_entity_relationships(test_data)
+    assert f"No collection with id {coll_import_id} found for family" == e.value.message
+
+
 def test_save_documents_when_no_family():
     fam_import_id = "test.new.family.0"
     test_data = {


### PR DESCRIPTION
# Description
- validate that all collections listed referenced in the families exist in the ingest json
- refactor the entity relationships validation logic to remove duplication

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
