### PR TITLE
Feature/pdct 1499 add a limit to how many documents can be ingested in one go

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,7 @@ jobs:
       checks: write
       # For repo checkout
       contents: read
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/python-precommit-validator.yml@v10
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/python-precommit-validator.yml@v16
 
   test:
     if: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       (! startsWith(github.ref, 'refs/tags') && ! startsWith(github.ref, 'refs/heads/main'))
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v3
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/check-auto-tagging-will-work.yml@v10
 
   code-quality:
     if: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,7 @@ jobs:
       checks: write
       # For repo checkout
       contents: read
-    uses: climatepolicyradar/reusable-workflows/.github/workflows/python-precommit-validator.yml@v3
+    uses: climatepolicyradar/reusable-workflows/.github/workflows/python-precommit-validator.yml@v10
 
   test:
     if: |

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -28,6 +28,8 @@ from app.model.ingest import (
     IngestFamilyDTO,
 )
 
+DOCUMENT_INGEST_LIMIT = 1000
+
 
 class IngestEntityList(str, Enum):
     """Name of the list of entities that can be ingested."""
@@ -124,11 +126,14 @@ def save_documents(
     validation.validate_documents(document_data, corpus_import_id)
 
     document_import_ids = []
+    saved_documents_counter = 0
 
     for doc in document_data:
-        dto = IngestDocumentDTO(**doc).to_document_create_dto()
-        import_id = document_repository.create(db, dto)
-        document_import_ids.append(import_id)
+        if saved_documents_counter < DOCUMENT_INGEST_LIMIT:
+            dto = IngestDocumentDTO(**doc).to_document_create_dto()
+            import_id = document_repository.create(db, dto)
+            document_import_ids.append(import_id)
+            saved_documents_counter += 1
 
     return document_import_ids
 

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -71,16 +71,32 @@ def save_collections(
     return collection_import_ids
 
 
-def family_exists_in_db(db, import_id):
-    return db.query(Family).filter(Family.import_id == import_id).one_or_none()
+def _family_exists_in_db(db: Session, import_id: str) -> bool:
+    """
+    Check if a family exists in the database by import_id.
+
+    :param Session db: The database session.
+    :param str import_id: The import_id of the family.
+    :return bool: True if the family exists, False otherwise.
+    """
+    family_exists = db.query(Family).filter(Family.import_id == import_id).one_or_none()
+    return family_exists is not None
 
 
-def document_exists_in_db(db, import_id):
-    return (
+def _document_exists_in_db(db: Session, import_id: str) -> bool:
+    """
+    Check if a document exists in the database by import_id.
+
+    :param Session db: The database session.
+    :param str import_id: The import_id of the document.
+    :return bool: True if the document exists, False otherwise.
+    """
+    document_exists = (
         db.query(FamilyDocument)
         .filter(FamilyDocument.import_id == import_id)
         .one_or_none()
     )
+    return document_exists is not None
 
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
@@ -107,7 +123,7 @@ def save_families(
     org_id = corpus.get_corpus_org_id(corpus_import_id)
 
     for fam in family_data:
-        if not family_exists_in_db(db, fam["import_id"]):
+        if not _family_exists_in_db(db, fam["import_id"]):
             dto = IngestFamilyDTO(
                 **fam, corpus_import_id=corpus_import_id
             ).to_family_create_dto(corpus_import_id)
@@ -144,7 +160,7 @@ def save_documents(
 
     for doc in document_data:
         if (
-            not document_exists_in_db(db, doc["import_id"])
+            not _document_exists_in_db(db, doc["import_id"])
             and saved_documents_counter < DOCUMENT_INGEST_LIMIT
         ):
             dto = IngestDocumentDTO(**doc).to_document_create_dto()

--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -92,8 +92,6 @@ def save_families(
     org_id = corpus.get_corpus_org_id(corpus_import_id)
 
     for fam in family_data:
-        # TODO: Uncomment when implementing feature/pdct-1402-validate-collection-exists-before-creating-family
-        # collection.validate(collections, db)
         dto = IngestFamilyDTO(
             **fam, corpus_import_id=corpus_import_id
         ).to_family_create_dto(corpus_import_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.15.3"
+version = "2.16.0"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/ingest/test_ingest.py
+++ b/tests/integration_tests/ingest/test_ingest.py
@@ -113,7 +113,15 @@ def test_ingest_rollback(
 def test_ingest_idempotency(data_db: Session, client: TestClient, user_header_token):
     family_import_id = "test.new.family.0"
     event_import_id = "test.new.event.0"
+    collection_import_id = "test.new.collection.0"
     test_data = {
+        "collections": [
+            {
+                "import_id": collection_import_id,
+                "title": "Test title",
+                "description": "Test description",
+            },
+        ],
         "families": [
             {
                 "import_id": family_import_id,
@@ -122,7 +130,7 @@ def test_ingest_idempotency(data_db: Session, client: TestClient, user_header_to
                 "geographies": ["South Asia"],
                 "category": "UNFCCC",
                 "metadata": {"author_type": ["Non-Party"], "author": ["Test"]},
-                "collections": [],
+                "collections": [collection_import_id],
             }
         ],
         "documents": [
@@ -158,6 +166,7 @@ def test_ingest_idempotency(data_db: Session, client: TestClient, user_header_to
 
     assert [family_import_id] == response.json()["families"]
     assert [event_import_id] == response.json()["events"]
+    assert [collection_import_id] == response.json()["collections"]
     assert "test.new.document.1000" not in response.json()["documents"]
 
     response = client.post(
@@ -168,6 +177,7 @@ def test_ingest_idempotency(data_db: Session, client: TestClient, user_header_to
 
     assert not response.json()["families"]
     assert not response.json()["events"]
+    assert not response.json()["collections"]
     assert ["test.new.document.1000"] == response.json()["documents"]
 
 

--- a/tests/mocks/repos/collection_repo.py
+++ b/tests/mocks/repos/collection_repo.py
@@ -57,7 +57,7 @@ def mock_collection_repo(collection_repo, monkeypatch: MonkeyPatch, mocker):
         maybe_throw()
         if collection_repo.return_empty:
             raise exc.NoResultFound()
-        return "test.new.collection.0"
+        return data.import_id if data.import_id else "test.new.collection.0"
 
     def mock_delete(_, import_id: str) -> bool:
         maybe_throw()

--- a/tests/mocks/repos/document_repo.py
+++ b/tests/mocks/repos/document_repo.py
@@ -59,7 +59,7 @@ def mock_document_repo(document_repo, monkeypatch: MonkeyPatch, mocker):
         maybe_throw()
         if document_repo.return_empty:
             raise exc.NoResultFound()
-        return "test.new.doc.0"
+        return data.import_id if data.import_id else "test.new.doc.0"
 
     def mock_delete(_, import_id: str) -> bool:
         maybe_throw()

--- a/tests/mocks/repos/family_repo.py
+++ b/tests/mocks/repos/family_repo.py
@@ -56,7 +56,9 @@ def update(db: Session, import_id: str, family: FamilyWriteDTO, geo_id: int) -> 
 
 def create(db: Session, family: FamilyCreateDTO, geo_id: int, org_id: int) -> str:
     _maybe_throw()
-    return "" if family_repo.return_empty else "created"
+    if family_repo.return_empty:
+        return ""
+    return family.import_id if family.import_id else "created"
 
 
 def delete(db: Session, import_id: str) -> bool:

--- a/tests/unit_tests/routers/ingest/test_ingest.py
+++ b/tests/unit_tests/routers/ingest/test_ingest.py
@@ -7,6 +7,7 @@ This uses service mocks and ensures the endpoint calls into each service.
 import io
 import json
 import os
+from unittest.mock import Mock, patch
 
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -19,6 +20,7 @@ def test_ingest_when_not_authenticated(client: TestClient):
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
+@patch("app.service.ingest._exists_in_db", Mock(return_value=False))
 def test_ingest_data_when_ok(
     client: TestClient,
     user_header_token,
@@ -95,8 +97,12 @@ def test_ingest_when_no_data(
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
+@patch("app.service.ingest._exists_in_db", Mock(return_value=False))
 def test_ingest_data_when_db_error(
-    client: TestClient, user_header_token, corpus_repo_mock, collection_repo_mock
+    client: TestClient,
+    user_header_token,
+    corpus_repo_mock,
+    collection_repo_mock,
 ):
     collection_repo_mock.throw_repository_error = True
 

--- a/tests/unit_tests/routers/ingest/test_ingest.py
+++ b/tests/unit_tests/routers/ingest/test_ingest.py
@@ -45,9 +45,9 @@ def test_ingest_data_when_ok(
 
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json() == {
-        "collections": ["test.new.collection.0", "test.new.collection.0"],
-        "families": ["created", "created"],
-        "documents": ["test.new.doc.0", "test.new.doc.0"],
+        "collections": ["test.new.collection.0", "test.new.collection.1"],
+        "families": ["test.new.family.0", "test.new.family.1"],
+        "documents": ["test.new.document.0", "test.new.document.1"],
     }
 
 

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -111,6 +111,29 @@ def test_save_documents_when_data_invalid(validation_service_mock):
     assert "Error" == e.value.message
 
 
+def test_save_documents_when_no_family():
+    fam_import_id = "test.new.family.0"
+    test_data = {
+        "documents": [
+            {"import_id": "test.new.document.0", "family_import_id": fam_import_id}
+        ]
+    }
+
+    with pytest.raises(ValidationError) as e:
+        ingest_service.import_data(test_data, "test")
+    assert f"No entity with id {fam_import_id} found" == e.value.message
+
+
+def test_save_events_when_data_invalid(validation_service_mock):
+    validation_service_mock.throw_validation_error = True
+
+    test_data = [{"import_id": "invalid"}]
+
+    with pytest.raises(ValidationError) as e:
+        ingest_service.save_events(test_data, "test")
+    assert "Error" == e.value.message
+
+
 def test_validate_entity_relationships_when_no_family_matching_document():
     fam_import_id = "test.new.family.0"
     test_data = {
@@ -144,26 +167,3 @@ def test_validate_entity_relationships_when_no_collection_matching_family():
     with pytest.raises(ValidationError) as e:
         ingest_service.validate_entity_relationships(test_data)
     assert f"No entity with id {coll_import_id} found" == e.value.message
-
-
-def test_save_documents_when_no_family():
-    fam_import_id = "test.new.family.0"
-    test_data = {
-        "documents": [
-            {"import_id": "test.new.document.0", "family_import_id": fam_import_id}
-        ]
-    }
-
-    with pytest.raises(ValidationError) as e:
-        ingest_service.import_data(test_data, "test")
-    assert f"No entity with id {fam_import_id} found" == e.value.message
-
-
-def test_save_events_when_data_invalid(validation_service_mock):
-    validation_service_mock.throw_validation_error = True
-
-    test_data = [{"import_id": "imvalid"}]
-
-    with pytest.raises(ValidationError) as e:
-        ingest_service.save_events(test_data, "test")
-    assert "Error" == e.value.message

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -6,6 +7,7 @@ import app.service.ingest as ingest_service
 from app.errors import RepositoryError, ValidationError
 
 
+@patch("app.service.ingest._exists_in_db", Mock(return_value=False))
 def test_ingest_when_ok(
     corpus_repo_mock,
     geography_repo_mock,
@@ -64,6 +66,7 @@ def test_ingest_when_ok(
     } == ingest_service.import_data(test_data, "test")
 
 
+@patch("app.service.ingest._exists_in_db", Mock(return_value=False))
 def test_ingest_when_db_error(corpus_repo_mock, collection_repo_mock):
     collection_repo_mock.throw_repository_error = True
 
@@ -111,6 +114,7 @@ def test_save_documents_when_data_invalid(validation_service_mock):
     assert "Error" == e.value.message
 
 
+@patch("app.service.ingest._exists_in_db", Mock(return_value=False))
 def test_do_not_save_documents_over_ingest_limit(
     validation_service_mock, document_repo_mock, monkeypatch
 ):

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -101,31 +101,6 @@ def test_save_families_when_data_invalid(corpus_repo_mock, validation_service_mo
     assert "Error" == e.value.message
 
 
-# TODO: Uncomment when implementing feature/pdct-1402-validate-collection-exists-before-creating-family
-# def test_ingest_families_when_collection_ids_do_not_exist(
-#     corpus_repo_mock, geography_repo_mock, collection_repo_mock
-# ):
-#     collection_repo_mock.missing = True
-
-#     test_data = {
-#         "families": [
-#             {
-#                 "import_id": "test.new.family.0",
-#                 "title": "Test",
-#                 "summary": "Test",
-#                 "geography": "Test",
-#                 "category": "UNFCCC",
-#                 "metadata": {},
-#                 "collections": ["id.does.not.exist"],
-#             },
-#         ],
-#     }
-#     with pytest.raises(ValidationError) as e:
-#         ingest_service.import_data(test_data, "test")
-#     expected_msg = "One or more of the collections to update does not exist"
-#     assert e.value.message == expected_msg
-
-
 def test_save_documents_when_data_invalid(validation_service_mock):
     validation_service_mock.throw_validation_error = True
 

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -58,8 +58,8 @@ def test_ingest_when_ok(
 
     assert {
         "collections": ["test.new.collection.0"],
-        "families": ["created"],
-        "documents": ["test.new.doc.0"],
+        "families": ["test.new.family.0"],
+        "documents": ["test.new.document.0"],
         "events": ["test.new.event.0"],
     } == ingest_service.import_data(test_data, "test")
 
@@ -111,7 +111,37 @@ def test_save_documents_when_data_invalid(validation_service_mock):
     assert "Error" == e.value.message
 
 
-def test_save_documents_when_no_family():
+def test_do_not_save_documents_over_ingest_limit(
+    validation_service_mock, document_repo_mock, monkeypatch
+):
+    monkeypatch.setattr(ingest_service, "DOCUMENT_INGEST_LIMIT", 1)
+
+    test_data = [
+        {
+            "import_id": "test.new.document.0",
+            "family_import_id": "test.new.family.0",
+            "variant_name": "Original Language",
+            "metadata": {"color": ["blue"]},
+            "title": "",
+            "source_url": None,
+            "user_language_name": "",
+        },
+        {
+            "import_id": "test.new.document.1",
+            "family_import_id": "test.new.family.1",
+            "variant_name": "Original Language",
+            "metadata": {"color": ["blue"]},
+            "title": "",
+            "source_url": None,
+            "user_language_name": "",
+        },
+    ]
+
+    saved_documents = ingest_service.save_documents(test_data, "test")
+    assert ["test.new.document.0"] == saved_documents
+
+
+def test_ingest_documents_when_no_family():
     fam_import_id = "test.new.family.0"
     test_data = {
         "documents": [


### PR DESCRIPTION
# Description
- max 1000 documents can be saved in one ingest - any more are ignored
- ingest is idempotent so the same json file can be used to ingest any remaining documents

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
