### PR TITLE
ci: Reduce reviewers scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 # review when someone opens a pull request. Teams should
 # be identified in the format @org/team-name. Teams must have
 # explicit write access to the repository.
-* @climatepolicyradar/tech-devs
+* @climatepolicyradar/software


### PR DESCRIPTION
# Description

Similar to climatepolicyradar/navigator-admin-frontend#84, and the others!

## Proposed version

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Similar change has been successfully made in other repositories, and GitHub validates changes to this file automatically.

## Reviewer Checklist

- [x] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [x] The PR represents a single feature (small drive-by fixes are also ok)
- [x] The PR includes tests that are sufficient for the level of risk
- [x] The code is sufficiently commented, particularly in hard-to-understand areas
- [x] Any required documentation updates have been made
- [x] Any TODOs added are captured in future tickets
- [x] No FIXMEs remain
