### PR TITLE
Comment s3 backup logic back in + test refactor

### DIFF
--- a/app/service/ingest.py
+++ b/app/service/ingest.py
@@ -8,6 +8,7 @@ import of data and other services for validation etc.
 import logging
 from enum import Enum
 from typing import Any, Optional, Type, TypeVar
+from uuid import uuid4
 
 from db_client.models.dfce.collection import Collection
 from db_client.models.dfce.family import Family, FamilyDocument, FamilyEvent
@@ -24,6 +25,7 @@ import app.service.corpus as corpus
 import app.service.geography as geography
 import app.service.notification as notification_service
 import app.service.validation as validation
+from app.clients.aws.s3bucket import upload_ingest_json_to_s3
 from app.model.ingest import (
     IngestCollectionDTO,
     IngestDocumentDTO,
@@ -240,8 +242,8 @@ def import_data(data: dict[str, Any], corpus_import_id: str) -> None:
     )
     end_message = ""
 
-    # ingest_uuid = uuid4()
-    # upload_ingest_json_to_s3(f"{ingest_uuid}-request", corpus_import_id, data)
+    ingest_uuid = uuid4()
+    upload_ingest_json_to_s3(f"{ingest_uuid}-request", corpus_import_id, data)
 
     _LOGGER.info("Getting DB session")
 
@@ -270,7 +272,7 @@ def import_data(data: dict[str, Any], corpus_import_id: str) -> None:
             _LOGGER.info("Saving events")
             result["events"] = save_events(event_data, corpus_import_id, db)
 
-        # upload_ingest_json_to_s3(f"{ingest_uuid}-result", corpus_import_id, result)
+        upload_ingest_json_to_s3(f"{ingest_uuid}-result", corpus_import_id, result)
 
         end_message = (
             f"🎉 Bulk import for corpus: {corpus_import_id} successfully completed."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.17.7"
+version = "2.17.8"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/mocks/repos/corpus_repo.py
+++ b/tests/mocks/repos/corpus_repo.py
@@ -2,14 +2,19 @@ from typing import Optional
 
 from pytest import MonkeyPatch
 
+from app.errors import ValidationError
+
 
 def mock_corpus_repo(corpus_repo, monkeypatch: MonkeyPatch, mocker):
     corpus_repo.error = False
     corpus_repo.valid = True
 
-    def mock_get_corpus_org_id(_, __) -> Optional[int]:
-        if not corpus_repo.error:
-            return 1
+    def mock_get_corpus_org_id(_, corpus_org_id) -> Optional[int]:
+        if corpus_repo.error:
+            raise ValidationError(
+                f"No organisation associated with corpus {corpus_org_id}"
+            )
+        return 1
 
     def mock_validate(_, __) -> bool:
         return corpus_repo.valid

--- a/tests/unit_tests/service/ingest/test_ingest_service.py
+++ b/tests/unit_tests/service/ingest/test_ingest_service.py
@@ -9,120 +9,72 @@ import app.service.ingest as ingest_service
 from app.errors import ValidationError
 
 
-@pytest.mark.skip("This code tests S3 and needs reinstating when that work is done.")
-@patch("app.service.ingest._exists_in_db", Mock(return_value=False))
+@patch("app.service.ingest.uuid4", Mock(return_value="1111-1111"))
 @patch.dict(os.environ, {"BULK_IMPORT_BUCKET": "test_bucket"})
-def test_ingest_when_ok(
-    basic_s3_client,
-    corpus_repo_mock,
-    geography_repo_mock,
-    collection_repo_mock,
-    family_repo_mock,
-    document_repo_mock,
-    event_repo_mock,
-    validation_service_mock,
+@patch("app.service.ingest._exists_in_db", Mock(return_value=False))
+def test_input_json_and_result_saved_to_s3_on_bulk_import(
+    basic_s3_client, validation_service_mock, corpus_repo_mock, collection_repo_mock
 ):
     bucket_name = "test_bucket"
-    test_data = {
+    json_data = {
         "collections": [
             {
                 "import_id": "test.new.collection.0",
-                "title": "Test title",
-                "description": "Test description",
-            },
-        ],
-        "families": [
-            {
-                "import_id": "test.new.family.0",
-                "title": "Test",
-                "summary": "Test",
-                "geographies": ["Test"],
-                "category": "UNFCCC",
-                "metadata": {"color": ["blue"], "size": [""]},
-                "collections": ["test.new.collection.0"],
-            },
-        ],
-        "documents": [
-            {
-                "import_id": "test.new.document.0",
-                "family_import_id": "test.new.family.0",
-                "variant_name": "Original Language",
-                "metadata": {"color": ["blue"]},
-                "title": "",
-                "source_url": None,
-                "user_language_name": "",
-            }
-        ],
-        "events": [
-            {
-                "import_id": "test.new.event.0",
-                "family_import_id": "test.new.family.0",
-                "event_title": "Test",
-                "date": "2000-01-01T00:00:00.000Z",
-                "event_type_value": "Amended",
-            }
-        ],
-    }
-
-    expected_ingest_result = {
-        "collections": ["test.new.collection.0"],
-        "families": ["test.new.family.0"],
-        "documents": ["test.new.document.0"],
-        "events": ["test.new.event.0"],
-    }
-
-    try:
-        with (
-            patch(
-                "app.service.ingest.notification_service.send_notification"
-            ) as mock_notification_service,
-        ):
-            ingest_service.import_data(test_data, "test_corpus_id")
-
-            response = basic_s3_client.list_objects_v2(
-                Bucket=bucket_name, Prefix="1111-1111-result-test_corpus_id"
-            )
-
-            assert 2 == mock_notification_service.call_count
-            mock_notification_service.assert_called_with(
-                "🎉 Bulk import for corpus: test_corpus_id successfully completed."
-            )
-
-            objects = response["Contents"]
-            assert len(objects) == 1
-
-            key = objects[0]["Key"]
-            response = basic_s3_client.get_object(Bucket=bucket_name, Key=key)
-            body = response["Body"].read().decode("utf-8")
-            assert expected_ingest_result == json.loads(body)
-    except Exception as e:
-        assert False, f"import_data in ingest service raised an exception: {e}"
-
-
-@patch.dict(os.environ, {"BULK_IMPORT_BUCKET": "test_bucket"})
-def test_import_data_when_data_invalid(caplog, basic_s3_client):
-    test_data = {
-        "collections": [
-            {
-                "import_id": "invalid",
                 "title": "Test title",
                 "description": "Test description",
             }
         ]
     }
 
-    with caplog.at_level(logging.ERROR):
-        ingest_service.import_data(test_data, "test")
+    ingest_service.import_data(json_data, "test_corpus_id")
 
-    assert "The import id invalid is invalid!" in caplog.text
+    bulk_import_input_json = basic_s3_client.list_objects_v2(
+        Bucket=bucket_name, Prefix="1111-1111-result-test_corpus_id"
+    )
+    objects = bulk_import_input_json["Contents"]
+    assert len(objects) == 1
+
+    key = objects[0]["Key"]
+    bulk_import_result = basic_s3_client.get_object(Bucket=bucket_name, Key=key)
+    body = bulk_import_result["Body"].read().decode("utf-8")
+    assert {"collections": ["test.new.collection.0"]} == json.loads(body)
 
 
 @patch("app.service.ingest._exists_in_db", Mock(return_value=False))
 @patch.dict(os.environ, {"BULK_IMPORT_BUCKET": "test_bucket"})
-def test_ingest_when_db_error(
-    caplog, basic_s3_client, corpus_repo_mock, collection_repo_mock
+def test_slack_notification_sent_on_success(
+    basic_s3_client,
+    corpus_repo_mock,
+    collection_repo_mock,
+    validation_service_mock,
 ):
-    collection_repo_mock.throw_repository_error = True
+    test_data = {
+        "collections": [
+            {
+                "import_id": "test.new.collection.0",
+                "title": "Test title",
+                "description": "Test description",
+            }
+        ],
+    }
+
+    with (
+        patch(
+            "app.service.ingest.notification_service.send_notification"
+        ) as mock_notification_service,
+    ):
+        ingest_service.import_data(test_data, "test_corpus_id")
+
+        assert 2 == mock_notification_service.call_count
+        mock_notification_service.assert_called_with(
+            "🎉 Bulk import for corpus: test_corpus_id successfully completed."
+        )
+
+
+@patch("app.service.ingest._exists_in_db", Mock(return_value=False))
+@patch.dict(os.environ, {"BULK_IMPORT_BUCKET": "test_bucket"})
+def test_slack_notification_sent_on_error(caplog, basic_s3_client, corpus_repo_mock):
+    corpus_repo_mock.error = True
 
     test_data = {
         "collections": [
@@ -147,31 +99,27 @@ def test_ingest_when_db_error(
         "💥 Bulk import for corpus: test has failed."
     )
     assert (
-        "Rolling back transaction due to the following error: bad collection repo"
+        "Rolling back transaction due to the following error: No organisation associated with corpus test"
         in caplog.text
     )
 
 
-@pytest.mark.skip("This code tests S3 and needs reinstating when that work is done.")
 @patch.dict(os.environ, {"BULK_IMPORT_BUCKET": "test_bucket"})
-def test_request_json_saved_to_s3_on_ingest(basic_s3_client):
-    bucket_name = "test_bucket"
-    json_data = {"key": "value"}
+def test_import_data_when_data_invalid(caplog, basic_s3_client):
+    test_data = {
+        "collections": [
+            {
+                "import_id": "invalid",
+                "title": "Test title",
+                "description": "Test description",
+            }
+        ]
+    }
 
-    ingest_service.import_data({"key": "value"}, "test_corpus_id")
+    with caplog.at_level(logging.ERROR):
+        ingest_service.import_data(test_data, "test")
 
-    response = basic_s3_client.list_objects_v2(
-        Bucket=bucket_name, Prefix="1111-1111-request-test_corpus_id"
-    )
-
-    assert "Contents" in response
-    objects = response["Contents"]
-    assert len(objects) == 1
-
-    key = objects[0]["Key"]
-    response = basic_s3_client.get_object(Bucket=bucket_name, Key=key)
-    body = response["Body"].read().decode("utf-8")
-    assert json.loads(body) == json_data
+    assert "The import id invalid is invalid!" in caplog.text
 
 
 def test_save_families_when_corpus_invalid(corpus_repo_mock, validation_service_mock):


### PR DESCRIPTION
# Description

- bring back logic to save bulk import request json and result to S3
- refactor unit tests to be more meaningful and robust

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
