### PR TITLE
Feature/pdct 1542 metadata validation with pydantic

### DIFF
--- a/app/model/bulk_import.py
+++ b/app/model/bulk_import.py
@@ -1,13 +1,15 @@
 from datetime import datetime
-from typing import Optional
+from typing import Dict, List, Optional, Union
 
-from pydantic import AnyHttpUrl, BaseModel
+from pydantic import AnyHttpUrl, BaseModel, RootModel
 
 from app.model.collection import CollectionCreateDTO
 from app.model.document import DocumentCreateDTO
 from app.model.event import EventCreateDTO
 from app.model.family import FamilyCreateDTO
 from app.model.general import Json
+
+Metadata = RootModel[Dict[str, Union[str, List[str]]]]
 
 
 class BulkImportCollectionDTO(BaseModel):
@@ -38,7 +40,7 @@ class BulkImportFamilyDTO(BaseModel):
     summary: str
     geographies: list[str]
     category: str
-    metadata: Json
+    metadata: Metadata
     collections: list[str]
     corpus_import_id: str
 
@@ -54,7 +56,7 @@ class BulkImportFamilyDTO(BaseModel):
             summary=self.summary,
             geography=self.geographies,
             category=self.category,
-            metadata=self.metadata,
+            metadata=self.metadata.model_dump(),
             collections=self.collections,
             corpus_import_id=corpus_import_id,
         )

--- a/app/model/bulk_import.py
+++ b/app/model/bulk_import.py
@@ -7,7 +7,6 @@ from app.model.collection import CollectionCreateDTO
 from app.model.document import DocumentCreateDTO
 from app.model.event import EventCreateDTO
 from app.model.family import FamilyCreateDTO
-from app.model.general import Json
 
 Metadata = RootModel[Dict[str, Union[str, List[str]]]]
 
@@ -93,7 +92,7 @@ class BulkImportDocumentDTO(BaseModel):
     import_id: str
     family_import_id: str
     variant_name: Optional[str] = None
-    metadata: Json
+    metadata: Metadata
     title: str
     source_url: Optional[AnyHttpUrl] = None
     user_language_name: Optional[str] = None
@@ -109,7 +108,7 @@ class BulkImportDocumentDTO(BaseModel):
             import_id=self.import_id,
             family_import_id=self.family_import_id,
             variant_name=self.variant_name,
-            metadata=self.metadata,
+            metadata=self.metadata.model_dump(),
             title=self.title,
             source_url=self.source_url,
             user_language_name=self.user_language_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.17.19"
+version = "2.17.20"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
+++ b/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
@@ -7,7 +7,7 @@ import pytest
 
 import app.service.bulk_import as bulk_import_service
 from app.errors import ValidationError
-from tests.helpers.bulk_import import default_collection, default_family
+from tests.helpers.bulk_import import default_document, default_family
 
 
 @patch("app.service.bulk_import.uuid4", Mock(return_value="1111-1111"))
@@ -105,17 +105,24 @@ def test_slack_notification_sent_on_error(caplog, basic_s3_client, corpus_repo_m
     )
 
 
-@pytest.mark.parametrize("test_metadata", [{"key": [1]}, {"key": None}, {"key": 1}])
+@pytest.mark.parametrize(
+    "test_data",
+    [
+        {"families": [{**default_family, "metadata": {"key": [1]}}]},
+        {"families": [{**default_family, "metadata": {"key": None}}]},
+        {"families": [{**default_family, "metadata": {"key": 1}}]},
+        {"documents": [{**default_document, "metadata": {"key": 1}}]},
+    ],
+)
 @patch.dict(os.environ, {"BULK_IMPORT_BUCKET": "test_bucket"})
 @patch("app.service.bulk_import._exists_in_db", Mock(return_value=False))
 def test_import_data_when_metadata_contains_non_string_values(
-    test_metadata, corpus_repo_mock, validation_service_mock, caplog, basic_s3_client
+    test_data,
+    corpus_repo_mock,
+    validation_service_mock,
+    caplog,
+    basic_s3_client,
 ):
-    test_data = {
-        "collections": [default_collection],
-        "families": [{**default_family, "metadata": test_metadata}],
-    }
-
     with caplog.at_level(logging.ERROR):
         bulk_import_service.import_data(test_data, "test")
 


### PR DESCRIPTION
# Description

Please include:

- use the pydantic data models to validate that family and document metadata contains only list or list[str] values

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
