### PR TITLE
Feature/pdct 1722 fix corpus import id generator

### DIFF
--- a/app/model/corpus.py
+++ b/app/model/corpus.py
@@ -37,6 +37,7 @@ class CorpusWriteDTO(BaseModel):
 class CorpusCreateDTO(BaseModel):
     """Representation of a Corpus."""
 
+    import_id: Optional[str] = None
     title: str
     description: str
     corpus_text: Optional[str]

--- a/app/repository/config.py
+++ b/app/repository/config.py
@@ -47,7 +47,12 @@ def _to_corpus_data(row) -> CorpusData:
         description=row.description,
         corpus_type=row.corpus_type,
         corpus_type_description=row.corpus_type_description,
-        organisation={"name": row.org_name, "id": row.org_id},
+        organisation={
+            "name": row.org_name,
+            "id": row.org_id,
+            "display_name": row.org_display_name,
+            "type": row.org_type,
+        },
         taxonomy={**row.taxonomy},
     )
 
@@ -62,6 +67,8 @@ def get_corpora(db: Session, user: UserContext) -> Sequence[CorpusData]:
             CorpusType.description.label("corpus_type_description"),
             Organisation.name.label("org_name"),
             Organisation.id.label("org_id"),
+            Organisation.display_name.label("org_display_name"),
+            Organisation.organisation_type.label("org_type"),
             CorpusType.valid_metadata.label("taxonomy"),
         )
         .join(

--- a/app/repository/corpus.py
+++ b/app/repository/corpus.py
@@ -281,7 +281,11 @@ def create(db: Session, corpus: CorpusCreateDTO) -> str:
     :return str: The ID of the created corpus.
     """
     try:
-        import_id = generate_import_id(db, CountedEntity.Corpus, corpus.organisation_id)
+        import_id = (
+            generate_import_id(db, CountedEntity.Corpus, corpus.organisation_id)
+            if corpus.import_id is None
+            else corpus.import_id
+        )
         new_corpus = Corpus(
             import_id=import_id,
             title=corpus.title,

--- a/app/repository/organisation.py
+++ b/app/repository/organisation.py
@@ -10,3 +10,13 @@ def get_id_from_name(db: Session, org_name: str) -> Optional[int]:
 
 def get_name_from_id(db: Session, org_id: int) -> Optional[str]:
     return db.query(Organisation.name).filter_by(id=org_id).scalar()
+
+
+def get_distinct_org_options(db: Session) -> list[str]:
+    query = db.query(Organisation).all()
+
+    # Combine organisation_type values with name unique values into a single list.
+    org_names = [org.name for org in query]
+    org_types = [org.organisation_type for org in query]
+    options = list(set(org_names + org_types))
+    return options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.17.26"
+version = "2.17.27"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/helpers/corpus.py
+++ b/tests/helpers/corpus.py
@@ -26,8 +26,10 @@ def create_corpus_create_dto(
     corpus_text: Optional[str] = "corpus_text",
     image_url: Optional[str] = "some-picture.png",
     org_id: int = 1,
+    import_id: Optional[str] = None,
 ) -> CorpusCreateDTO:
     return CorpusCreateDTO(
+        import_id=import_id,
         title=title,
         description=description,
         corpus_text=corpus_text,

--- a/tests/integration_tests/corpus/test_create.py
+++ b/tests/integration_tests/corpus/test_create.py
@@ -1,3 +1,4 @@
+import pytest
 from db_client.models.organisation.corpus import Corpus
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -209,3 +210,35 @@ def test_create_corpus_when_db_error(
     data = response.json()
     assert data["detail"] == "Bad Repo"
     assert bad_corpus_repo.create.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "import_id",
+    [
+        "invalid_import_id",
+        "CCLW.family.i00000002.n0001",
+        "TEST.corpus.i00000001.n0001",
+    ],
+)
+def test_create_corpus_when_invalid_import_id(
+    client: TestClient,
+    data_db: Session,
+    superuser_header_token,
+    import_id: str,
+):
+    setup_db(data_db)
+    new_corpus = create_corpus_create_dto("Laws and Policies", import_id=import_id)
+    response = client.post(
+        "/api/v1/corpora",
+        json=new_corpus.model_dump(),
+        headers=superuser_header_token,
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    data = response.json()
+    assert data["detail"] == "Invalid import ID"
+
+    actual_corpus = (
+        data_db.query(Corpus).filter(Corpus.import_id == import_id).one_or_none()
+    )
+    assert actual_corpus is None


### PR DESCRIPTION
# Description

- Allow corpus import ID to be passed on create
- Add validation for corpus import ID
- Add test case

Note: The API remains dumb in -how- the corpus import IDs are generated for now. Instead, we will make the frontend build the desired import ID based on the options the user selects, and then we will use the backend to validate that the import ID is valid. 

This is because corpus import IDs aren't currently standardised entirely. For example, the below are all examples of corpus import IDs:
- UNFCCC.corpus.i00000001.n0000
- MCF.corpus.GCF.n0000
- MCF.corpus.GCF.Guidance

The matching frontend PR for this ticket will allow the user to build the corpus import ID using the following criteria:
- The import ID will contain 4 parts
- The first part will contain either the organisation name (not the org display name) or the organisation type
- The second part will always be 'corpus'
- The third part will be the organisation name if the first part contains the organisation type, otherwise the third part will contain a numbered index
- The fourth part will either be a numbered index as default, or free text that the user can input

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
