### PR TITLE
fix: implement multi-geographies on the search endpoint

### DIFF
--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -44,73 +44,6 @@ FamilyGeoMetaOrg = Tuple[
 ]
 
 
-def _get_query_search_endpoint(db: Session) -> Query:
-    # NOTE: SqlAlchemy will make a complete hash of query generation
-    #       if columns are used in the query() call. Therefore, entire
-    #       objects are returned.
-    # NOTE: Whilst we are updating the queries to handle multiple geographies, we are keeping
-    #       the returned results for search as they are currently to enable backwards
-    #       compatibility, and as to not extend beyond this pr.
-    return (
-        db.query(Family, Geography, FamilyMetadata, Corpus, Organisation)
-        .join(FamilyGeography, FamilyGeography.family_import_id == Family.import_id)
-        .join(
-            Geography,
-            Geography.id == FamilyGeography.geography_id,
-        )
-        .join(FamilyMetadata, FamilyMetadata.family_import_id == Family.import_id)
-        .join(FamilyCorpus, FamilyCorpus.family_import_id == Family.import_id)
-        .join(Corpus, Corpus.import_id == FamilyCorpus.corpus_import_id)
-        .join(Organisation, Corpus.organisation_id == Organisation.id)
-    )
-
-
-def _family_to_dto_search_endpoint(
-    db: Session,
-    fam_geo_meta_corp_org: Tuple[
-        Family,
-        Geography,
-        FamilyMetadata,
-        Corpus,
-        Organisation,
-    ],
-) -> FamilyReadDTO:
-    # NOTE: Whilst we are updating the queries to handle multiple geographies, we are keeping
-    #       the returned results for search as they are currently to enable backwards
-    #       compatibility, and as to not extend beyond this pr.
-    fam, geo_value, meta, corpus, org = fam_geo_meta_corp_org
-    metadata = cast(dict, meta.value)
-    org = cast(str, org.name)
-
-    return FamilyReadDTO(
-        import_id=str(fam.import_id),
-        title=str(fam.title),
-        summary=str(fam.description),
-        geography=str(geo_value.value),
-        geographies=[str(geo_value.value)],
-        category=str(fam.family_category),
-        status=str(fam.family_status),
-        metadata=metadata,
-        slug=str(fam.slugs[0].name if len(fam.slugs) > 0 else ""),
-        events=[str(e.import_id) for e in fam.events],
-        published_date=fam.published_date,
-        last_updated_date=fam.last_updated_date,
-        documents=[str(d.import_id) for d in fam.family_documents],
-        collections=[
-            c.collection_import_id
-            for c in db.query(CollectionFamily).filter(
-                fam.import_id == CollectionFamily.family_import_id
-            )
-        ],
-        organisation=org,
-        corpus_import_id=cast(str, corpus.import_id),
-        corpus_title=cast(str, corpus.title),
-        corpus_type=cast(str, corpus.corpus_type_name),
-        created=cast(datetime, fam.created),
-        last_modified=cast(datetime, fam.last_modified),
-    )
-
-
 def get_family_geography_subquery(db: Session) -> Subquery:
     """
     Creates a subquery to aggregate geography values for families, accomodating
@@ -344,10 +277,8 @@ def search(
             search.append(Family.description.ilike(term))
 
     if geography is not None:
-        geography_filter = or_(
-            *[(Geography.display_value == g.title()) for g in geography]
-        )
-        search.append(geography_filter)
+        import_ids = _get_family_import_ids_by_geographies(db, geography)
+        search.append(Family.import_id.in_(import_ids))
 
     if "status" in search_params.keys():
         term = cast(str, search_params["status"])
@@ -356,7 +287,7 @@ def search(
     condition = and_(*search) if len(search) > 1 else search[0]
 
     try:
-        query = _get_query_search_endpoint(db).filter(condition)
+        query = _get_query(db).filter(condition)
         if org_id is not None:
             query = query.filter(Organisation.id == org_id)
 
@@ -371,7 +302,7 @@ def search(
             raise TimeoutError
         raise RepositoryError(e)
 
-    return [_family_to_dto_search_endpoint(db, f) for f in found]
+    return [_family_to_dto(db, f) for f in found]
 
 
 def update(
@@ -765,3 +696,21 @@ def perform_family_geographies_update(db: Session, import_id: str, geo_ids: list
 
     remove_old_geographies(db, import_id, geo_ids, original_geographies)
     add_new_geographies(db, import_id, geo_ids, original_geographies)
+
+
+def _get_family_import_ids_by_geographies(db: Session, geographies: list[str]) -> Query:
+    """
+    Filters import IDs of families based on the provided geography values.
+    :param db Session: the database connection
+    :param list[str] geographies: A list of geography display values to filter by
+    :return Query: A subquery containing the filtered family import IDs
+    """
+
+    return (
+        db.query(
+            FamilyGeography.family_import_id,
+        )
+        .join(Geography, Geography.id == FamilyGeography.geography_id)
+        .filter(Geography.display_value.in_(geographies))
+        .subquery()
+    )

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -338,7 +338,13 @@ def update(
     ) = _update_intention(db, import_id, family, geo_id, geo_ids, original_family)
 
     # Return if nothing to do
-    if not (update_title or update_basics or update_metadata or update_collections):
+    if not (
+        update_title
+        or update_basics
+        or update_metadata
+        or update_collections
+        or update_geographies
+    ):
         return True
 
     # Update basic fields

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.17.30"
+version = "2.17.31"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/family/test_search.py
+++ b/tests/integration_tests/family/test_search.py
@@ -58,9 +58,9 @@ def test_search_geographies(
     )
 
     tests_cases = [
-        (["afghanistan"], ["A.0.0.1", "A.0.0.3"]),
-        (["zimbabwe"], ["A.0.0.2"]),
-        (["albania", "zambia"], ["A.0.0.4", "A.0.0.5"]),
+        (["Afghanistan"], ["A.0.0.1", "A.0.0.3"]),
+        (["Zimbabwe"], ["A.0.0.2"]),
+        (["Albania", "Zambia"], ["A.0.0.4", "A.0.0.5"]),
     ]
 
     for countries, expected_ids in tests_cases:
@@ -126,7 +126,7 @@ def test_search_retrieves_families_with_multiple_geographies(
         ],
     )
 
-    test_geography = {"display_name": "albania", "iso_code": "ALB"}
+    test_geography = {"display_name": "Albania", "iso_code": "ALB"}
 
     geographies_query = f"&geography={test_geography['display_name']}"
     response = client.get(

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -523,12 +523,9 @@ def _setup_family_data(
     num_families = len(initial_data)
     for index in range(num_families):
         data = initial_data[index]
-
-        geo_id = (
-            test_db.query(Geography.id)
-            .filter(Geography.value == data["geography"])
-            .scalar()
-        )
+        geographies = (
+            test_db.query(Geography).filter(Geography.value.in_(data["geographies"]))
+        ).all()
 
         test_db.add(
             Family(
@@ -538,9 +535,13 @@ def _setup_family_data(
                 family_category=data["category"],
             )
         )
-        test_db.add(
-            FamilyGeography(family_import_id=data["import_id"], geography_id=geo_id)
-        )
+        family_geographies = [
+            FamilyGeography(
+                family_import_id=data["import_id"], geography_id=geography.id
+            )
+            for geography in geographies
+        ]
+        test_db.add_all(family_geographies)
 
         corpus = (
             test_db.query(Corpus)


### PR DESCRIPTION
# Description

Implement multi-geographies on the search endpoint. 
Had originally left out this change out of the PR for the retrieve/list endpoints - but it seems that it still needed a fix
As you can see on the screenshot the list of the family page, which infact uses the search endpoint
Would return duplicate rows families where there was more than one associated family, which had been fixed in this[ PR](https://github.com/climatepolicyradar/navigator-admin-backend/pull/268/commits/21c04d00ce66789c3451c8b62532d83d9c58d1a2) 

Screenshots
<img width="1429" alt="Screenshot 2025-01-09 at 16 50 13" src="https://github.com/user-attachments/assets/e78ecda4-adda-4996-92d5-f3201f934a3c" />



Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
