### PR TITLE
Add /get and /all for organisations

### DIFF
--- a/app/api/api_v1/routers/__init__.py
+++ b/app/api/api_v1/routers/__init__.py
@@ -8,6 +8,7 @@ from app.api.api_v1.routers.corpus_type import corpus_types_router
 from app.api.api_v1.routers.document import document_router
 from app.api.api_v1.routers.event import event_router
 from app.api.api_v1.routers.family import families_router
+from app.api.api_v1.routers.organisation import organisations_router
 
 __all__ = (
     "analytics_router",
@@ -19,5 +20,6 @@ __all__ = (
     "document_router",
     "event_router",
     "families_router",
+    "organisations_router",
     "bulk_import_router",
 )

--- a/app/api/api_v1/routers/organisation.py
+++ b/app/api/api_v1/routers/organisation.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Union
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.errors import RepositoryError, ValidationError
+from app.model.organisation import OrganisationReadDTO
+from app.service import organisation as organisation_service
+
+organisations_router = APIRouter()
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@organisations_router.get(
+    "/organisations",
+    response_model=list[OrganisationReadDTO],
+)
+async def get_all_organisations() -> list[OrganisationReadDTO]:
+    """Retrieve all organisations.
+
+    :raises HTTPException: If the corpus type is not found.
+    :return CorpusTypeReadDTO: The requested corpus type.
+    """
+    try:
+        return organisation_service.all()
+    except RepositoryError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message
+        )
+
+
+@organisations_router.get(
+    "/organisations/{organisation}",
+    response_model=OrganisationReadDTO,
+)
+async def get_organisation(organisation: Union[int, str]) -> OrganisationReadDTO:
+    """Retrieve a specific organisation by its name.
+
+    :param Union[int, str] organisation: The ID or name of the
+        organisation to retrieve.
+    :raises HTTPException: If the organisation is not found.
+    :return OrganisationReadDTO: The requested organisation.
+    """
+    try:
+        org = organisation_service.get(organisation)
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
+    except RepositoryError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=e.message
+        )
+
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Organisation not found: {organisation}",
+        )
+    return org

--- a/app/api/api_v1/routers/organisation.py
+++ b/app/api/api_v1/routers/organisation.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Union
 
 from fastapi import APIRouter, HTTPException, status
 
@@ -34,11 +33,10 @@ async def get_all_organisations() -> list[OrganisationReadDTO]:
     "/organisations/{organisation}",
     response_model=OrganisationReadDTO,
 )
-async def get_organisation(organisation: Union[int, str]) -> OrganisationReadDTO:
+async def get_organisation(organisation: int) -> OrganisationReadDTO:
     """Retrieve a specific organisation by its name.
 
-    :param Union[int, str] organisation: The ID or name of the
-        organisation to retrieve.
+    :param int organisation: The ID of the organisation to retrieve.
     :raises HTTPException: If the organisation is not found.
     :return OrganisationReadDTO: The requested organisation.
     """

--- a/app/api/api_v1/routers/organisation.py
+++ b/app/api/api_v1/routers/organisation.py
@@ -30,18 +30,18 @@ async def get_all_organisations() -> list[OrganisationReadDTO]:
 
 
 @organisations_router.get(
-    "/organisations/{organisation}",
+    "/organisations/{organisation_id}",
     response_model=OrganisationReadDTO,
 )
-async def get_organisation(organisation: int) -> OrganisationReadDTO:
+async def get_organisation(organisation_id: int) -> OrganisationReadDTO:
     """Retrieve a specific organisation by its name.
 
-    :param int organisation: The ID of the organisation to retrieve.
+    :param int organisation_id: The ID of the organisation to retrieve.
     :raises HTTPException: If the organisation is not found.
     :return OrganisationReadDTO: The requested organisation.
     """
     try:
-        org = organisation_service.get(organisation)
+        org = organisation_service.get(organisation_id)
     except ValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)
     except RepositoryError as e:
@@ -52,6 +52,6 @@ async def get_organisation(organisation: int) -> OrganisationReadDTO:
     if org is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Organisation not found: {organisation}",
+            detail=f"Organisation not found: {organisation_id}",
         )
     return org

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.api.api_v1.routers import (
     document_router,
     event_router,
     families_router,
+    organisations_router,
 )
 from app.api.api_v1.routers.auth import check_user_auth
 from app.clients.db.session import engine
@@ -117,6 +118,13 @@ app.include_router(
     corpus_types_router,
     prefix="/api/v1",
     tags=["corpus-types"],
+    dependencies=[Depends(check_user_auth)],
+)
+
+app.include_router(
+    organisations_router,
+    prefix="/api/v1",
+    tags=["organisations"],
     dependencies=[Depends(check_user_auth)],
 )
 

--- a/app/model/authorisation.py
+++ b/app/model/authorisation.py
@@ -21,6 +21,7 @@ class AuthEndpoint(str, enum.Enum):
     BULK_IMPORT = "BULK-IMPORT"
     CORPUS = "CORPORA"
     CORPUS_TYPE = "CORPUS-TYPES"
+    ORGANISATION = "ORGANISATIONS"
 
 
 AuthMap = Mapping[AuthEndpoint, Mapping[AuthOperation, AuthAccess]]
@@ -76,6 +77,10 @@ AUTH_TABLE: AuthMap = {
     # Corpus Type
     AuthEndpoint.CORPUS_TYPE: {
         AuthOperation.CREATE: AuthAccess.SUPER,
+        AuthOperation.READ: AuthAccess.SUPER,
+    },
+    # Organisation
+    AuthEndpoint.ORGANISATION: {
         AuthOperation.READ: AuthAccess.SUPER,
     },
 }

--- a/app/model/organisation.py
+++ b/app/model/organisation.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class OrganisationReadDTO(BaseModel):
+    """Representation of an Organisation."""
+
+    id: int
+    internal_name: str
+    display_name: str
+    description: str
+    type: str

--- a/app/repository/organisation.py
+++ b/app/repository/organisation.py
@@ -78,21 +78,3 @@ def get_by_id(db: Session, org_id: int) -> Optional[OrganisationReadDTO]:
         raise RepositoryError(e)
 
     return _org_to_dto(org) if org is not None else None
-
-
-def get_by_name(db: Session, org_name: str) -> Optional[OrganisationReadDTO]:
-    """Get an organisation from the database given a name.
-
-    :param db Session: The database connection.
-    :param str org_name: The name of the organisation to retrieve.
-    :return Optional[OrganisationReadDTO]: The requested org or None.
-    :raises RepositoryError: If there is an error during query.
-    """
-    try:
-        org = db.query(Organisation).filter(Organisation.name == org_name).one_or_none()
-
-    except MultipleResultsFound as e:
-        _LOGGER.error(e)
-        raise RepositoryError(e)
-
-    return _org_to_dto(org) if org is not None else None

--- a/app/repository/organisation.py
+++ b/app/repository/organisation.py
@@ -70,6 +70,7 @@ def get_by_id(db: Session, org_id: int) -> Optional[OrganisationReadDTO]:
     :raises RepositoryError: If there is an error during query.
     """
     try:
+        _LOGGER.info(db.query(Organisation).all())
         org = db.query(Organisation).filter(Organisation.id == org_id).one_or_none()
 
     except MultipleResultsFound as e:

--- a/app/repository/organisation.py
+++ b/app/repository/organisation.py
@@ -1,7 +1,15 @@
-from typing import Optional
+import logging
+from typing import Optional, cast
 
 from db_client.models.organisation.users import Organisation
+from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import asc
+
+from app.errors import RepositoryError
+from app.model.organisation import OrganisationReadDTO
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def get_id_from_name(db: Session, org_name: str) -> Optional[int]:
@@ -20,3 +28,70 @@ def get_distinct_org_options(db: Session) -> list[str]:
     org_types = [org.organisation_type for org in query]
     options = list(set(org_names + org_types))
     return options
+
+
+def _org_to_dto(org: Organisation) -> OrganisationReadDTO:
+    """Convert an Organisation model to a OrganisationReadDTO.
+
+    :param Organisation org: The org model.
+    :return OrganisationReadDTO: The corresponding DTO.
+    """
+    return OrganisationReadDTO(
+        id=cast(int, org.id),
+        internal_name=str(org.name),
+        display_name=str(org.display_name),
+        description=str(org.description),
+        type=str(org.organisation_type),
+    )
+
+
+def all(db: Session) -> list[OrganisationReadDTO]:
+    """Get a list of all corpus types in the database.
+
+    :param db Session: The database connection.
+    :return OrganisationReadDTO: The requested organisation.
+    :raises RepositoryError: If the corpus type is not found.
+    """
+    query = db.query(Organisation)
+    result = query.order_by(asc(Organisation.name)).all()
+
+    if not result:
+        return []
+
+    return [_org_to_dto(org) for org in result]
+
+
+def get_by_id(db: Session, org_id: int) -> Optional[OrganisationReadDTO]:
+    """Get an organisation from the database given an ID.
+
+    :param db Session: The database connection.
+    :param int org_id: The ID of the organisation to retrieve.
+    :return Optional[OrganisationReadDTO]: The requested org or None.
+    :raises RepositoryError: If there is an error during query.
+    """
+    try:
+        org = db.query(Organisation).filter(Organisation.id == org_id).one_or_none()
+
+    except MultipleResultsFound as e:
+        _LOGGER.error(e)
+        raise RepositoryError(e)
+
+    return _org_to_dto(org) if org is not None else None
+
+
+def get_by_name(db: Session, org_name: str) -> Optional[OrganisationReadDTO]:
+    """Get an organisation from the database given a name.
+
+    :param db Session: The database connection.
+    :param str org_name: The name of the organisation to retrieve.
+    :return Optional[OrganisationReadDTO]: The requested org or None.
+    :raises RepositoryError: If there is an error during query.
+    """
+    try:
+        org = db.query(Organisation).filter(Organisation.name == org_name).one_or_none()
+
+    except MultipleResultsFound as e:
+        _LOGGER.error(e)
+        raise RepositoryError(e)
+
+    return _org_to_dto(org) if org is not None else None

--- a/app/service/organisation.py
+++ b/app/service/organisation.py
@@ -1,7 +1,15 @@
+import logging
+from typing import Optional, Union
+
+from pydantic import ConfigDict, validate_call
 from sqlalchemy.orm import Session
 
+import app.clients.db.session as db_session
 from app.errors import ValidationError
-from app.repository import organisation_repo
+from app.model.organisation import OrganisationReadDTO
+from app.repository import organisation as organisation_repo
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def get_id_from_name(db: Session, org_name: str) -> int:
@@ -9,3 +17,32 @@ def get_id_from_name(db: Session, org_name: str) -> int:
     if id is None:
         raise ValidationError(f"The organisation name {org_name} is invalid!")
     return id
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def all() -> list[OrganisationReadDTO]:
+    """Get the entire list of organisations from the repository.
+
+    :return list[OrganisationReadDTO]: The list of organisations.
+    """
+    with db_session.get_db() as db:
+        return organisation_repo.all(db)
+
+
+@validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+def get(
+    organisation: Union[int, str], db: Optional[Session] = None
+) -> Optional[OrganisationReadDTO]:
+    """Retrieve an organisation by ID or name.
+
+    :param Union[int, str] organisation: The name or ID of an
+        organisation to retrieve.
+    :return OrganisationReadDTO: The requested organisation.
+    :raises RepositoryError: If there is an error during retrieval.
+    """
+    if db is None:
+        db = db_session.get_db()
+
+    if isinstance(organisation, int):
+        return organisation_repo.get_by_id(db, organisation)
+    return organisation_repo.get_by_name(db, organisation)

--- a/app/service/organisation.py
+++ b/app/service/organisation.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union
+from typing import Optional
 
 from pydantic import ConfigDict, validate_call
 from sqlalchemy.orm import Session
@@ -31,18 +31,15 @@ def all() -> list[OrganisationReadDTO]:
 
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def get(
-    organisation: Union[int, str], db: Optional[Session] = None
+    organisation: int, db: Optional[Session] = None
 ) -> Optional[OrganisationReadDTO]:
     """Retrieve an organisation by ID or name.
 
-    :param Union[int, str] organisation: The name or ID of an
-        organisation to retrieve.
+    :param int organisation: The ID of an organisation to retrieve.
     :return OrganisationReadDTO: The requested organisation.
     :raises RepositoryError: If there is an error during retrieval.
     """
     if db is None:
         db = db_session.get_db()
 
-    if isinstance(organisation, int):
-        return organisation_repo.get_by_id(db, organisation)
-    return organisation_repo.get_by_name(db, organisation)
+    return organisation_repo.get_by_id(db, organisation)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.17.33"
+version = "2.17.34"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/organisation/test_all.py
+++ b/tests/integration_tests/organisation/test_all.py
@@ -31,7 +31,7 @@ def test_get_all_organisations(
         assert all(key in EXPECTED_ORG_KEYS for key in item)
 
     # Check CCLW content.
-    cclw_org = data[0]
+    cclw_org = data[2]
     assert cclw_org == EXPECTED_CCLW_ORG
 
     # Check UNFCCC content.

--- a/tests/integration_tests/organisation/test_all.py
+++ b/tests/integration_tests/organisation/test_all.py
@@ -31,11 +31,11 @@ def test_get_all_organisations(
         assert all(key in EXPECTED_ORG_KEYS for key in item)
 
     # Check CCLW content.
-    cclw_org = data[2]
+    cclw_org = data[1]
     assert cclw_org == EXPECTED_CCLW_ORG
 
     # Check UNFCCC content.
-    unfccc_org = data[1]
+    unfccc_org = data[-1]
     assert unfccc_org == EXPECTED_UNFCCC_ORG
 
 

--- a/tests/integration_tests/organisation/test_all.py
+++ b/tests/integration_tests/organisation/test_all.py
@@ -1,0 +1,64 @@
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from tests.integration_tests.setup_db import (
+    EXPECTED_CCLW_ORG,
+    EXPECTED_NUM_ORGS,
+    EXPECTED_UNFCCC_ORG,
+    setup_db,
+)
+
+EXPECTED_ORG_KEYS = ["internal_name", "description", "display_name", "type", "id"]
+
+
+def test_get_all_organisations(
+    client: TestClient, data_db: Session, superuser_header_token
+):
+    setup_db(data_db)
+    response = client.get(
+        "/api/v1/organisations",
+        headers=superuser_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) > 0  # Ensure there are corpus types returned
+
+    assert len(data) == EXPECTED_NUM_ORGS
+    for item in data:
+        assert isinstance(item, dict)
+        assert all(key in EXPECTED_ORG_KEYS for key in item)
+
+    # Check CCLW content.
+    cclw_org = data[0]
+    assert cclw_org == EXPECTED_CCLW_ORG
+
+    # Check UNFCCC content.
+    unfccc_org = data[1]
+    assert unfccc_org == EXPECTED_UNFCCC_ORG
+
+
+def test_get_all_organisations_non_super(
+    client: TestClient, data_db: Session, user_header_token
+):
+    setup_db(data_db)
+    response = client.get(
+        "/api/v1/organisations",
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    data = response.json()
+    assert (
+        data["detail"] == "User cclw@cpr.org is not authorised to READ an ORGANISATION"
+    )
+
+
+def test_get_all_organisations_when_not_authenticated(
+    client: TestClient, data_db: Session
+):
+    setup_db(data_db)
+    response = client.get(
+        "/api/v1/organisations",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/integration_tests/organisation/test_get.py
+++ b/tests/integration_tests/organisation/test_get.py
@@ -1,0 +1,81 @@
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from tests.integration_tests.setup_db import (
+    EXPECTED_CCLW_ORG,
+    EXPECTED_UNFCCC_ORG,
+    setup_db,
+)
+
+EXPECTED_ORG_KEYS = ["internal_name", "description", "display_name", "type", "id"]
+
+
+@pytest.mark.parametrize(
+    "expected_organisation",
+    [EXPECTED_CCLW_ORG, EXPECTED_UNFCCC_ORG],
+)
+def test_get_organisation_by_internal_name(
+    client: TestClient, data_db: Session, superuser_header_token, expected_organisation
+):
+    setup_db(data_db)
+    response = client.get(
+        f"/api/v1/organisations/{expected_organisation['internal_name']}",
+        headers=superuser_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    assert set(EXPECTED_ORG_KEYS) == set(data.keys())
+    assert data == expected_organisation
+
+
+@pytest.mark.parametrize(
+    "expected_organisation",
+    [EXPECTED_CCLW_ORG, EXPECTED_UNFCCC_ORG],
+)
+def test_get_organisation_by_id(
+    client: TestClient, data_db: Session, superuser_header_token, expected_organisation
+):
+    setup_db(data_db)
+    response = client.get(
+        f"/api/v1/organisations/{expected_organisation['id']}",
+        headers=superuser_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    assert set(EXPECTED_ORG_KEYS) == set(data.keys())
+    assert data == expected_organisation
+
+
+def test_get_organisation_non_super(
+    client: TestClient, data_db: Session, user_header_token
+):
+    setup_db(data_db)
+    response = client.get("/api/v1/organisations/CCLW", headers=user_header_token)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    data = response.json()
+    assert data["detail"] == "User cclw@cpr.org is not authorised to READ a CORPUS_TYPE"
+
+
+def test_get_organisation_when_not_authenticated(client: TestClient, data_db: Session):
+    setup_db(data_db)
+    response = client.get(
+        "/api/v1/organisations/CCLW",
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_get_organisation_when_not_found(
+    client: TestClient, data_db: Session, superuser_header_token
+):
+    setup_db(data_db)
+    response = client.get(
+        "/api/v1/organisations/NonExistentType",
+        headers=superuser_header_token,
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert data["detail"] == "Organisation not found: NonExistentType"

--- a/tests/integration_tests/organisation/test_get.py
+++ b/tests/integration_tests/organisation/test_get.py
@@ -16,25 +16,6 @@ EXPECTED_ORG_KEYS = ["internal_name", "description", "display_name", "type", "id
     "expected_organisation",
     [EXPECTED_CCLW_ORG, EXPECTED_UNFCCC_ORG],
 )
-def test_get_organisation_by_internal_name(
-    client: TestClient, data_db: Session, superuser_header_token, expected_organisation
-):
-    setup_db(data_db)
-    response = client.get(
-        f"/api/v1/organisations/{expected_organisation['internal_name']}",
-        headers=superuser_header_token,
-    )
-    assert response.status_code == status.HTTP_200_OK
-    data = response.json()
-
-    assert set(EXPECTED_ORG_KEYS) == set(data.keys())
-    assert data == expected_organisation
-
-
-@pytest.mark.parametrize(
-    "expected_organisation",
-    [EXPECTED_CCLW_ORG, EXPECTED_UNFCCC_ORG],
-)
 def test_get_organisation_by_id(
     client: TestClient, data_db: Session, superuser_header_token, expected_organisation
 ):
@@ -54,7 +35,7 @@ def test_get_organisation_non_super(
     client: TestClient, data_db: Session, user_header_token
 ):
     setup_db(data_db)
-    response = client.get("/api/v1/organisations/CCLW", headers=user_header_token)
+    response = client.get("/api/v1/organisations/1", headers=user_header_token)
     assert response.status_code == status.HTTP_403_FORBIDDEN
     data = response.json()
     assert (
@@ -65,7 +46,7 @@ def test_get_organisation_non_super(
 def test_get_organisation_when_not_authenticated(client: TestClient, data_db: Session):
     setup_db(data_db)
     response = client.get(
-        "/api/v1/organisations/CCLW",
+        "/api/v1/organisations/1",
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -75,9 +56,9 @@ def test_get_organisation_when_not_found(
 ):
     setup_db(data_db)
     response = client.get(
-        "/api/v1/organisations/NonExistentType",
+        "/api/v1/organisations/9999",
         headers=superuser_header_token,
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND
     data = response.json()
-    assert data["detail"] == "Organisation not found: NonExistentType"
+    assert data["detail"] == "Organisation not found: 9999"

--- a/tests/integration_tests/organisation/test_get.py
+++ b/tests/integration_tests/organisation/test_get.py
@@ -57,7 +57,9 @@ def test_get_organisation_non_super(
     response = client.get("/api/v1/organisations/CCLW", headers=user_header_token)
     assert response.status_code == status.HTTP_403_FORBIDDEN
     data = response.json()
-    assert data["detail"] == "User cclw@cpr.org is not authorised to READ a CORPUS_TYPE"
+    assert (
+        data["detail"] == "User cclw@cpr.org is not authorised to READ an ORGANISATION"
+    )
 
 
 def test_get_organisation_when_not_authenticated(client: TestClient, data_db: Session):

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -304,19 +304,19 @@ EXPECTED_CORPORA_KEYS = [
     "metadata",
 ]
 
-EXPECTED_NUM_ORGS = 2
+EXPECTED_NUM_ORGS = 3
 EXPECTED_CCLW_ORG = {
     "id": 1,
     "internal_name": "CCLW",
     "display_name": "CCLW",
-    "description": "CCLW",
+    "description": "LSE CCLW team",
     "type": "Academic",
 }
 EXPECTED_UNFCCC_ORG = {
     "id": 2,
     "internal_name": "UNFCCC",
     "display_name": "UNFCCC",
-    "description": "UNFCCC",
+    "description": "United Nations Framework Convention on Climate Change",
     "type": "UN",
 }
 

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -304,6 +304,22 @@ EXPECTED_CORPORA_KEYS = [
     "metadata",
 ]
 
+EXPECTED_NUM_ORGS = 2
+EXPECTED_CCLW_ORG = {
+    "id": 1,
+    "internal_name": "CCLW",
+    "display_name": "CCLW",
+    "description": "CCLW",
+    "type": "Academic",
+}
+EXPECTED_UNFCCC_ORG = {
+    "id": 2,
+    "internal_name": "UNFCCC",
+    "display_name": "UNFCCC",
+    "description": "UNFCCC",
+    "type": "UN",
+}
+
 
 def add_data(test_db: Session, data: list[DBEntry]):
     org_id = test_db.query(Organisation).filter(Organisation.name == "CCLW").one().id


### PR DESCRIPTION
# Description

Add /get and /all routes for organisations.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
