### PR TITLE
Exclude health endpoint from middleware timing logs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -60,7 +60,7 @@ app = FastAPI(
 )
 setup_json_logging(app)
 add_pagination(app)
-add_timing_middleware(app, record=_LOGGER.info)
+add_timing_middleware(app, record=_LOGGER.info, exclude="health")
 
 app.include_router(
     config_router,

--- a/app/main.py
+++ b/app/main.py
@@ -44,6 +44,7 @@ _ALLOW_ORIGIN_REGEX = (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.INFO)
 
 
 @asynccontextmanager

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -8,6 +8,7 @@ services:
     tty: true
     volumes:
       - ./tests:/usr/src/tests
+      - ./app:/usr/src/app
     environment:
       # This is for when people explicitly set the tests they want to run
       # It is used in the makefile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.18.1"
+version = "2.18.2"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.17.37"
+version = "2.18.1"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]


### PR DESCRIPTION
# Description

Adding the health endpoint to the middleware timing logs, makes the logs extremely noise and harder to sift through.

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
