### PR TITLE
Update bulk import relationship validation to return a list 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.18.12"
+version = "2.18.13"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit_tests/routers/bulk_import/test_bulk_import.py
+++ b/tests/unit_tests/routers/bulk_import/test_bulk_import.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 
 from fastapi import status
 from fastapi.testclient import TestClient
-
 from tests.helpers.bulk_import import (
     build_json_file,
     default_collection,
@@ -120,4 +119,4 @@ def test_bulk_import_documents_when_no_family(
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json().get("detail") == "No entity with id test.new.family.0 found"
+    assert response.json().get("detail") == "Missing entities: ['test.new.family.0']"

--- a/tests/unit_tests/routers/bulk_import/test_bulk_import.py
+++ b/tests/unit_tests/routers/bulk_import/test_bulk_import.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 from fastapi import status
 from fastapi.testclient import TestClient
+
 from tests.helpers.bulk_import import (
     build_json_file,
     default_collection,

--- a/tests/unit_tests/service/validation/test_entity_relationship_validation.py
+++ b/tests/unit_tests/service/validation/test_entity_relationship_validation.py
@@ -5,35 +5,68 @@ from app.service.validation import validate_entity_relationships
 
 
 def test_validate_entity_relationships_when_no_family_matching_document():
-    fam_import_id = "test.new.family.0"
+    missing_fam_import_id = "test.new.family.0"
     test_data = {
         "documents": [
-            {"import_id": "test.new.document.0", "family_import_id": fam_import_id}
+            {
+                "import_id": "test.new.document.0",
+                "family_import_id": missing_fam_import_id,
+            }
         ]
     }
 
     with pytest.raises(ValidationError) as e:
         validate_entity_relationships(test_data)
-    assert f"No entity with id {fam_import_id} found" == e.value.message
+    assert f"Missing entities: ['{missing_fam_import_id}']" == e.value.message
 
 
 def test_validate_entity_relationships_when_no_family_matching_event():
-    fam_import_id = "test.new.family.0"
+    missing_fam_import_id = "test.new.family.0"
     test_data = {
-        "events": [{"import_id": "test.new.event.0", "family_import_id": fam_import_id}]
+        "events": [
+            {"import_id": "test.new.event.0", "family_import_id": missing_fam_import_id}
+        ]
     }
 
     with pytest.raises(ValidationError) as e:
         validate_entity_relationships(test_data)
-    assert f"No entity with id {fam_import_id} found" == e.value.message
+    assert f"Missing entities: ['{missing_fam_import_id}']" == e.value.message
 
 
 def test_validate_entity_relationships_when_no_collection_matching_family():
-    coll_import_id = "test.new.collection.0"
+    missing_coll_import_id = "test.new.collection.0"
     test_data = {
-        "families": [{"import_id": "test.new.event.0", "collections": [coll_import_id]}]
+        "families": [
+            {"import_id": "test.new.family.0", "collections": [missing_coll_import_id]}
+        ]
     }
 
     with pytest.raises(ValidationError) as e:
         validate_entity_relationships(test_data)
-    assert f"No entity with id {coll_import_id} found" == e.value.message
+    assert f"Missing entities: ['{missing_coll_import_id}']" == e.value.message
+
+
+def test_validate_entity_relationships_includes_deduplicated_list_of_all_missing_entities_in_error_message():
+    missing_coll_import_id = "test.new.collection.0"
+    missing_fam_import_id = "test.new.family.1"
+    test_data = {
+        "families": [
+            {"import_id": "test.new.family.0", "collections": [missing_coll_import_id]}
+        ],
+        "documents": [
+            {
+                "import_id": "test.new.document.0",
+                "family_import_id": missing_fam_import_id,
+            }
+        ],
+        "events": [
+            {"import_id": "test.new.event.0", "family_import_id": missing_fam_import_id}
+        ],
+    }
+
+    with pytest.raises(ValidationError) as e:
+        validate_entity_relationships(test_data)
+    assert (
+        f"Missing entities: ['{missing_coll_import_id}', '{missing_fam_import_id}']"
+        == e.value.message
+    )


### PR DESCRIPTION
- update the json validation for bulk import to return a list of missing entities rather than error on the first found

# Description

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
