### PR TITLE
Fix/app 404 bug cannot create collections via the admin service

### DIFF
--- a/app/model/collection.py
+++ b/app/model/collection.py
@@ -25,7 +25,7 @@ class CollectionWriteDTO(BaseModel):
     title: str
     description: str
     organisation: str
-    metadata: Json
+    metadata: Optional[Json] = {}
 
 
 class CollectionCreateDTO(BaseModel):

--- a/app/model/collection.py
+++ b/app/model/collection.py
@@ -34,4 +34,4 @@ class CollectionCreateDTO(BaseModel):
     import_id: Optional[str] = None
     title: str
     description: str
-    metadata: Json
+    metadata: Optional[Json] = {}

--- a/app/repository/collection.py
+++ b/app/repository/collection.py
@@ -233,7 +233,6 @@ def create(db: Session, collection: CollectionCreateDTO, org_id: int) -> str:
         new_collection, collection_organisation = _collection_org_from_dto(
             collection, org_id
         )
-        print(">>>>>>>>>>", collection)
 
         if not new_collection.import_id:
             new_collection.import_id = cast(

--- a/app/repository/collection.py
+++ b/app/repository/collection.py
@@ -233,6 +233,7 @@ def create(db: Session, collection: CollectionCreateDTO, org_id: int) -> str:
         new_collection, collection_organisation = _collection_org_from_dto(
             collection, org_id
         )
+        print(">>>>>>>>>>", collection)
 
         if not new_collection.import_id:
             new_collection.import_id = cast(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.18.14"
+version = "2.18.15"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/collection/test_create.py
+++ b/tests/integration_tests/collection/test_create.py
@@ -3,15 +3,16 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.model.collection import CollectionCreateDTO
 from tests.helpers.collection import create_collection_create_dto
 from tests.integration_tests.setup_db import setup_db
 
 
-def test_create_collection(client: TestClient, data_db: Session, user_header_token):
+def test_create_collection_no_metadata(
+    client: TestClient, data_db: Session, user_header_token
+):
     setup_db(data_db)
-    new_collection = create_collection_create_dto(
-        title="Title", description="test test test", metadata={}
-    )
+    new_collection = CollectionCreateDTO(title="Title", description="test test test")
     response = client.post(
         "/api/v1/collections",
         json=new_collection.model_dump(),
@@ -26,6 +27,29 @@ def test_create_collection(client: TestClient, data_db: Session, user_header_tok
     assert actual_collection.title == "Title"
     assert actual_collection.description == "test test test"
     assert actual_collection.valid_metadata == {}
+
+
+def test_create_collection_with_metadata(
+    client: TestClient, data_db: Session, user_header_token
+):
+    setup_db(data_db)
+    new_collection = create_collection_create_dto(
+        title="Title", description="test test test", metadata={"key": "value"}
+    )
+    response = client.post(
+        "/api/v1/collections",
+        json=new_collection.model_dump(),
+        headers=user_header_token,
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data == "CCLW.collection.i00000002.n0000"
+    actual_collection = (
+        data_db.query(Collection).filter(Collection.import_id == data).one()
+    )
+    assert actual_collection.title == "Title"
+    assert actual_collection.description == "test test test"
+    assert actual_collection.valid_metadata == {"key": "value"}
 
 
 def test_create_collection_when_not_authenticated(client: TestClient, data_db: Session):


### PR DESCRIPTION
# Description
- make collection metadata field optional on the CollectionCreate and CollectionWrite models since not all corpora will have metadata for collections

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
