### PR TITLE
Add timings around bulk import and saving of each entity

### DIFF
--- a/app/service/bulk_import.py
+++ b/app/service/bulk_import.py
@@ -7,6 +7,7 @@ import of data and other services for validation etc.
 
 import logging
 import os
+import time
 from typing import Any, Optional
 from uuid import uuid4
 
@@ -154,6 +155,7 @@ def save_collections(
     :param Optional[Session] db: The database session to use for saving collections or None.
     :return list[str]: The new import_ids for the saved collections.
     """
+    start_time = time.time()
     if db is None:
         db = db_session.get_db()
 
@@ -182,7 +184,9 @@ def save_collections(
                 collection_import_ids.append(import_id)
                 total_collections_saved += 1
 
-    _LOGGER.info(f"Saved {total_collections_saved} collections")
+    _LOGGER.info(
+        f"Saved {total_collections_saved} collections in {time.time() - start_time} seconds"
+    )
     return collection_import_ids
 
 
@@ -200,7 +204,7 @@ def save_families(
     :param Optional[Session] db: The database session to use for saving families or None.
     :return list[str]: The new import_ids for the saved families.
     """
-
+    start_time = time.time()
     if db is None:
         db = db_session.get_db()
 
@@ -237,7 +241,9 @@ def save_families(
                 family_import_ids.append(import_id)
                 total_families_saved += 1
 
-    _LOGGER.info(f"Saved {total_families_saved} families")
+    _LOGGER.info(
+        f"Saved {total_families_saved} families in {time.time() - start_time} seconds"
+    )
 
     return family_import_ids
 
@@ -258,6 +264,7 @@ def save_documents(
     :param Optional[Session] db: The database session to use for saving documents or None.
     :return list[str]: The new import_ids for the saved documents.
     """
+    start_time = time.time()
     if db is None:
         db = db_session.get_db()
 
@@ -295,7 +302,9 @@ def save_documents(
                     document_import_ids.append(import_id)
                     total_documents_saved += 1
 
-    _LOGGER.info(f"Saved {total_documents_saved} documents")
+    _LOGGER.info(
+        f"Saved {total_documents_saved} documents in {time.time() - start_time} seconds"
+    )
     return document_import_ids
 
 
@@ -313,6 +322,7 @@ def save_events(
     :param Optional[Session] db: The database session to use for saving events or None.
     :return list[str]: The new import_ids for the saved events.
     """
+    start_time = time.time()
     if db is None:
         db = db_session.get_db()
 
@@ -343,7 +353,9 @@ def save_events(
                 event_import_ids.append(import_id)
                 total_events_saved += 1
 
-    _LOGGER.info(f"Saved {total_events_saved} events")
+    _LOGGER.info(
+        f"Saved {total_events_saved} events in {time.time() - start_time} seconds"
+    )
     return event_import_ids
 
 
@@ -362,6 +374,7 @@ def import_data(
     :raises RepositoryError: raised on a database error.
     :raises ValidationError: raised should the data be invalid.
     """
+    start_time = time.time()
     notification_service.send_notification(
         f"🚀 Bulk import for corpus: {corpus_import_id} has started."
     )
@@ -404,9 +417,7 @@ def import_data(
 
         upload_bulk_import_json_to_s3(f"{import_uuid}-result", corpus_import_id, result)
 
-        end_message = (
-            f"🎉 Bulk import for corpus: {corpus_import_id} successfully completed."
-        )
+        end_message = f"🎉 Bulk import for corpus: {corpus_import_id} successfully completed in {time.time() - start_time} seconds."
         db.commit()
     except Exception as e:
         _LOGGER.error(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.18.16"
+version = "2.18.17"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
+++ b/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
@@ -71,8 +71,10 @@ def test_slack_notification_sent_on_success(
         bulk_import_service.import_data(test_data, "test_corpus_id")
 
         assert 2 == mock_notification_service.call_count
-        mock_notification_service.assert_called_with(
-            "🎉 Bulk import for corpus: test_corpus_id successfully completed."
+        assert any(
+            "🎉 Bulk import for corpus: test_corpus_id successfully completed"
+            in call_args[0][0]
+            for call_args in mock_notification_service.call_args_list
         )
 
 


### PR DESCRIPTION
# Description

- add timings to the info logs around saving dfce entities and the how long the entire bulk import took

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
