### PR TITLE
Bulk import fixes

### DIFF
--- a/app/service/bulk_import.py
+++ b/app/service/bulk_import.py
@@ -415,10 +415,10 @@ def import_data(
             _LOGGER.info("Saving events")
             result["events"] = save_events(event_data, corpus_import_id, db)
 
-        upload_bulk_import_json_to_s3(f"{import_uuid}-result", corpus_import_id, result)
-
-        end_message = f"🎉 Bulk import for corpus: {corpus_import_id} successfully completed in {time.time() - start_time} seconds."
         db.commit()
+
+        upload_bulk_import_json_to_s3(f"{import_uuid}-result", corpus_import_id, result)
+        end_message = f"🎉 Bulk import for corpus: {corpus_import_id} successfully completed in {time.time() - start_time} seconds."
     except Exception as e:
         _LOGGER.error(
             f"Rolling back transaction due to the following error: {e}", exc_info=True

--- a/app/service/bulk_import.py
+++ b/app/service/bulk_import.py
@@ -337,9 +337,12 @@ def save_events(
         if not existing_event:
             _LOGGER.info(f"Importing event {import_id}")
             dto = BulkImportEventDTO(**event).to_event_create_dto()
-            event_metadata = create_event_metadata_object(
-                db, corpus_import_id, event["event_type_value"]
-            )
+            event_metadata = event.get("metadata")
+            # TODO: remove below when implementing APP-343
+            if not event_metadata:
+                event_metadata = create_event_metadata_object(
+                    db, corpus_import_id, event["event_type_value"]
+                )
             event_repository.create(db, dto, event_metadata)
             event_import_ids.append(import_id)
             total_events_saved += 1

--- a/app/service/validation.py
+++ b/app/service/validation.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 
 from db_client.models.dfce.taxonomy_entry import EntitySpecificTaxonomyKeys
 from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
 
 import app.clients.db.session as db_session
 import app.repository.corpus as corpus_repo
@@ -24,15 +25,17 @@ class BulkImportEntityList(str, Enum):
     Events = "events"
 
 
-def validate_collection(collection: dict[str, Any], corpus_import_id: str) -> None:
+def validate_collection(
+    db: Session, collection: dict[str, Any], corpus_import_id: str
+) -> None:
     """
     Validates a collection.
 
+    :param Session db: The database session to use for validating collections.
     :param dict[str, Any] collection: The collection object to be validated.
     :param str corpus_import_id: The corpus_import_id to be used for validating the collection object.
     :raises ValidationError: raised should the data be invalid.
     """
-    db = db_session.get_db()
 
     validate_import_id(collection["import_id"])
     metadata_value = collection.get("metadata")
@@ -54,20 +57,21 @@ def validate_collections(
     :param list[dict[str, Any]] collections: The list of collection objects to be validated.
     :param str corpus_import_id: The corpus_import_id to be used for validating the collection objects.
     """
+    db = db_session.get_db()
+
     for coll in collections:
-        validate_collection(coll, corpus_import_id)
+        validate_collection(db, coll, corpus_import_id)
 
 
-def validate_family(family: dict[str, Any], corpus_import_id: str) -> None:
+def validate_family(db: Session, family: dict[str, Any], corpus_import_id: str) -> None:
     """
     Validates a family.
 
+    :param Session db: The database session to use for validating families.
     :param dict[str, Any] family: The family object to be validated.
     :param str corpus_import_id: The corpus_import_id to be used for validating the family object.
     :raises ValidationError: raised should the data be invalid.
     """
-    db = db_session.get_db()
-
     validate_import_id(family["import_id"])
     corpus.validate(db, corpus_import_id)
     category.validate(family["category"])
@@ -83,20 +87,22 @@ def validate_families(families: list[dict[str, Any]], corpus_import_id: str) -> 
     :param list[dict[str, Any]] families: The list of family objects to be validated.
     :param str corpus_import_id: The corpus_import_id to be used for validating the family objects.
     """
+    db = db_session.get_db()
     for fam in families:
-        validate_family(fam, corpus_import_id)
+        validate_family(db, fam, corpus_import_id)
 
 
-def validate_document(document: dict[str, Any], corpus_import_id: str) -> None:
+def validate_document(
+    db: Session, document: dict[str, Any], corpus_import_id: str
+) -> None:
     """
     Validates a document.
 
+    :param Session db: The database session to use for validating documents.
     :param dict[str, Any] document: The document object to be validated.
     :param str corpus_import_id: The corpus_import_id to be used for validating the document object.
     :raises ValidationError: raised should the data be invalid.
     """
-    db = db_session.get_db()
-
     validate_import_id(document["import_id"])
     validate_import_id(document["family_import_id"])
     if document["variant_name"] == "":
@@ -116,14 +122,16 @@ def validate_documents(documents: list[dict[str, Any]], corpus_import_id: str) -
     :param list[dict[str, Any]] documents: The list of document objects to be validated.
     :param str corpus_import_id: The corpus_import_id to be used for validating the document objects.
     """
+    db = db_session.get_db()
     for doc in documents:
-        validate_document(doc, corpus_import_id)
+        validate_document(db, doc, corpus_import_id)
 
 
-def validate_event(event: dict[str, Any], corpus_import_id: str) -> None:
+def validate_event(db: Session, event: dict[str, Any], corpus_import_id: str) -> None:
     """
     Validates an event.
 
+    :param Session db: The database session to use for validating events.
     :param dict[str, Any] event: The event object to be validated.
     :param str corpus_import_id: The corpus_import_id to be used for
         validating the event object.
@@ -132,7 +140,6 @@ def validate_event(event: dict[str, Any], corpus_import_id: str) -> None:
     validate_import_id(event["import_id"])
     validate_import_id(event["family_import_id"])
 
-    db = db_session.get_db()
     event_metadata = event.get("metadata")
     # TODO: remove below when implementing APP-343
     if not event_metadata:
@@ -156,8 +163,9 @@ def validate_events(events: list[dict[str, Any]], corpus_import_id: str) -> None
     :param str corpus_import_id: The corpus_import_id to be used for
         validating the event objects.
     """
+    db = db_session.get_db()
     for ev in events:
-        validate_event(ev, corpus_import_id)
+        validate_event(db, ev, corpus_import_id)
 
 
 def _collect_import_ids(

--- a/app/service/validation.py
+++ b/app/service/validation.py
@@ -133,9 +133,12 @@ def validate_event(event: dict[str, Any], corpus_import_id: str) -> None:
     validate_import_id(event["family_import_id"])
 
     db = db_session.get_db()
-    event_metadata = create_event_metadata_object(
-        db, corpus_import_id, event["event_type_value"]
-    )
+    event_metadata = event.get("metadata")
+    # TODO: remove below when implementing APP-343
+    if not event_metadata:
+        event_metadata = create_event_metadata_object(
+            db, corpus_import_id, event["event_type_value"]
+        )
     metadata.validate_metadata(
         db,
         corpus_import_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.18.17"
+version = "2.18.18"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/mocks/repos/event_repo.py
+++ b/tests/mocks/repos/event_repo.py
@@ -53,7 +53,7 @@ def mock_event_repo(event_repo, monkeypatch: MonkeyPatch, mocker):
     def mock_create(_, data: EventCreateDTO, meta: dict[str, list[str]]) -> str:
         maybe_throw()
         if event_repo.throw_repository_error:
-            raise Exception("Error trying to create Event")
+            raise RepositoryError("Error trying to create Event")
         return "test.new.event.0"
 
     def mock_update(_, import_id: str, data: EventWriteDTO) -> EventReadDTO:

--- a/tests/mocks/repos/event_repo.py
+++ b/tests/mocks/repos/event_repo.py
@@ -52,8 +52,8 @@ def mock_event_repo(event_repo, monkeypatch: MonkeyPatch, mocker):
 
     def mock_create(_, data: EventCreateDTO, meta: dict[str, list[str]]) -> str:
         maybe_throw()
-        if event_repo.return_empty:
-            raise exc.NoResultFound()
+        if event_repo.throw_repository_error:
+            raise Exception("Error trying to create Event")
         return "test.new.event.0"
 
     def mock_update(_, import_id: str, data: EventWriteDTO) -> EventReadDTO:

--- a/tests/mocks/services/validation_service.py
+++ b/tests/mocks/services/validation_service.py
@@ -11,19 +11,19 @@ def mock_validation_service(validation_service, monkeypatch: MonkeyPatch, mocker
         if validation_service.throw_validation_error:
             raise ValidationError("Error")
 
-    def mock_validate_collection(_, __) -> None:
+    def mock_validate_collection(_, __, ___) -> None:
         maybe_throw()
 
-    def mock_validate_family(_, __) -> None:
+    def mock_validate_family(_, __, ___) -> None:
         maybe_throw()
 
     def mock_validate_families(_, __) -> None:
         maybe_throw()
 
-    def mock_validate_document(_, __) -> None:
+    def mock_validate_document(_, __, ___) -> None:
         maybe_throw()
 
-    def mock_validate_event(_, __) -> None:
+    def mock_validate_event(_, __, ___) -> None:
         maybe_throw()
 
     def mock_validate_events(_, __) -> None:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -6,7 +6,7 @@ Service mocks should only be used for router tests.
 
 import os
 from typing import Dict
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import boto3
 import db_client.functions.corpus_helpers as db_client_corpus_helpers
@@ -76,6 +76,11 @@ def client():
     """Get a TestClient instance that reads/write to the test database."""
 
     yield TestClient(app)
+
+
+@pytest.fixture
+def db_session_mock():
+    return MagicMock()
 
 
 # ----- Mock repos

--- a/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
+++ b/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 
@@ -204,6 +204,25 @@ def test_do_not_save_documents_over_bulk_import_limit(
 
     saved_documents = bulk_import_service.save_documents(test_data, "test", 1)
     assert ["test.new.document.0"] == saved_documents
+
+
+def test_save_events_with_correct_metadata(validation_service_mock, event_repo_mock):
+    event_repo_mock.return_empty = True
+    test_data = [
+        {
+            "import_id": "test.new.event.0",
+            "family_import_id": "test.new.family.0",
+            "family_document_import_id": "test.new.document.0",
+            "event_type_value": "Test event type",
+            "event_title": "Test event title",
+            "date": "2024-01-01",
+            "metadata": {"key": ["value"]},
+        }
+    ]
+
+    bulk_import_service.save_events(test_data, "test")
+
+    event_repo_mock.create.assert_called_with(ANY, ANY, test_data[0]["metadata"])
 
 
 def test_save_events_when_data_invalid(validation_service_mock):

--- a/tests/unit_tests/service/event/test_create_event_service.py
+++ b/tests/unit_tests/service/event/test_create_event_service.py
@@ -40,7 +40,7 @@ def test_create_when_db_fails(
     admin_user_context,
 ):
     new_event = create_event_create_dto()
-    event_repo_mock.return_empty = True
+    event_repo_mock.throw_repository_error = True
 
     with pytest.raises(RepositoryError):
         event_service.create(new_event, admin_user_context)

--- a/tests/unit_tests/service/validation/test_collection_validation.py
+++ b/tests/unit_tests/service/validation/test_collection_validation.py
@@ -4,19 +4,19 @@ import app.service.validation as validation_service
 from app.errors import ValidationError
 
 
-def test_validate_collection_when_ok(db_client_metadata_mock):
+def test_validate_collection_when_ok(db_client_metadata_mock, db_session_mock):
     test_collection = {
         "import_id": "test.new.collection.0",
         "metadata": {"color": ["pink"]},
     }
 
-    validation_service.validate_collection(test_collection, "test")
+    validation_service.validate_collection(db_session_mock, test_collection, "test")
 
 
-def test_validate_collection_when_import_id_invalid():
+def test_validate_collection_when_import_id_invalid(db_session_mock):
     invalid_import_id = "invalid"
     test_collection = {"import_id": invalid_import_id, "metadata": {}}
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_collection(test_collection, "test")
+        validation_service.validate_collection(db_session_mock, test_collection, "test")
     assert "The import id invalid is invalid!" == e.value.message

--- a/tests/unit_tests/service/validation/test_document_validation.py
+++ b/tests/unit_tests/service/validation/test_document_validation.py
@@ -4,7 +4,7 @@ import app.service.validation as validation_service
 from app.errors import ValidationError
 
 
-def test_validate_document_when_ok(db_client_metadata_mock):
+def test_validate_document_when_ok(db_client_metadata_mock, db_session_mock):
     test_document = {
         "import_id": "test.new.document.0",
         "family_import_id": "test.new.family.0",
@@ -12,21 +12,21 @@ def test_validate_document_when_ok(db_client_metadata_mock):
         "metadata": {"color": ["blue"]},
     }
 
-    validation_service.validate_document(test_document, "test")
+    validation_service.validate_document(db_session_mock, test_document, "test")
 
 
-def test_validate_document_when_import_id_wrong_format():
+def test_validate_document_when_import_id_wrong_format(db_session_mock):
     invalid_import_id = "invalid"
     test_document = {
         "import_id": invalid_import_id,
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_document(test_document, "test")
+        validation_service.validate_document(db_session_mock, test_document, "test")
     assert f"The import id {invalid_import_id} is invalid!" == e.value.message
 
 
-def test_validate_document_when_family_import_id_wrong_format():
+def test_validate_document_when_family_import_id_wrong_format(db_session_mock):
     invalid_family_import_id = "invalid"
     test_document = {
         "import_id": "test.new.document.0",
@@ -34,11 +34,11 @@ def test_validate_document_when_family_import_id_wrong_format():
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_document(test_document, "test")
+        validation_service.validate_document(db_session_mock, test_document, "test")
     assert f"The import id {invalid_family_import_id} is invalid!" == e.value.message
 
 
-def test_validate_document_when_variant_empty():
+def test_validate_document_when_variant_empty(db_session_mock):
     test_document = {
         "import_id": "test.new.document.0",
         "family_import_id": "test.new.family.0",
@@ -46,11 +46,13 @@ def test_validate_document_when_variant_empty():
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_document(test_document, "test")
+        validation_service.validate_document(db_session_mock, test_document, "test")
     assert "Variant name is empty" == e.value.message
 
 
-def test_validate_document_when_metadata_invalid(db_client_metadata_mock):
+def test_validate_document_when_metadata_invalid(
+    db_client_metadata_mock, db_session_mock
+):
     test_document = {
         "import_id": "test.new.document.0",
         "family_import_id": "test.new.family.0",
@@ -59,5 +61,5 @@ def test_validate_document_when_metadata_invalid(db_client_metadata_mock):
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_document(test_document, "test")
+        validation_service.validate_document(db_session_mock, test_document, "test")
     assert "Metadata validation failed: Missing metadata keys:" in e.value.message

--- a/tests/unit_tests/service/validation/test_entity_relationship_validation.py
+++ b/tests/unit_tests/service/validation/test_entity_relationship_validation.py
@@ -33,6 +33,41 @@ def test_validate_entity_relationships_when_no_family_matching_event():
     assert f"Missing entities: ['{missing_fam_import_id}']" == e.value.message
 
 
+def test_validate_entity_relationships_when_no_document_matching_event():
+    fam_import_id = "test.new.family.0"
+    missing_doc_import_id = "test.new.document.0"
+    test_data = {
+        "families": [{"import_id": fam_import_id, "collections": []}],
+        "events": [
+            {
+                "import_id": "test.new.event.0",
+                "family_import_id": fam_import_id,
+                "family_document_import_id": missing_doc_import_id,
+            }
+        ],
+    }
+
+    with pytest.raises(ValidationError) as e:
+        validate_entity_relationships(test_data)
+    assert f"Missing entities: ['{missing_doc_import_id}']" == e.value.message
+
+
+def test_validate_entity_relationships_handles_no_document_import_id_on_event():
+    fam_import_id = "test.new.family.0"
+    test_data = {
+        "families": [{"import_id": fam_import_id, "collections": []}],
+        "events": [
+            {
+                "import_id": "test.new.event.0",
+                "family_import_id": fam_import_id,
+                "family_document_import_id": None,
+            },
+        ],
+    }
+
+    validate_entity_relationships(test_data)
+
+
 def test_validate_entity_relationships_when_no_collection_matching_family():
     missing_coll_import_id = "test.new.collection.0"
     test_data = {

--- a/tests/unit_tests/service/validation/test_event_validation.py
+++ b/tests/unit_tests/service/validation/test_event_validation.py
@@ -6,7 +6,7 @@ import app.service.validation as validation_service
 from app.errors import ValidationError
 
 
-def test_validate_event_when_ok(db_client_metadata_mock):
+def test_validate_event_when_ok(db_client_metadata_mock, db_session_mock):
     event_metadata = {"color": ["pink"]}
     test_event = {
         "import_id": "test.new.event.0",
@@ -18,11 +18,11 @@ def test_validate_event_when_ok(db_client_metadata_mock):
         "app.service.validation.create_event_metadata_object",
         return_value=event_metadata,
     ) as mock_event_metadata:
-        validation_service.validate_event(test_event, "test")
+        validation_service.validate_event(db_session_mock, test_event, "test")
     assert mock_event_metadata.call_count == 1
 
 
-def test_validate_new_event_schema_when_ok(db_client_metadata_mock):
+def test_validate_new_event_schema_when_ok(db_client_metadata_mock, db_session_mock):
     test_event = {
         "import_id": "test.new.event.0",
         "family_import_id": "test.new.family.0",
@@ -31,21 +31,21 @@ def test_validate_new_event_schema_when_ok(db_client_metadata_mock):
         "metadata": {"color": ["pink"]},
     }
 
-    validation_service.validate_event(test_event, "test")
+    validation_service.validate_event(db_session_mock, test_event, "test")
 
 
-def test_validate_event_when_import_id_wrong_format():
+def test_validate_event_when_import_id_wrong_format(db_session_mock):
     invalid_import_id = "invalid"
     test_event = {
         "import_id": invalid_import_id,
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_event(test_event, "test")
+        validation_service.validate_event(db_session_mock, test_event, "test")
     assert f"The import id {invalid_import_id} is invalid!" == e.value.message
 
 
-def test_validate_event_when_family_import_id_wrong_format():
+def test_validate_event_when_family_import_id_wrong_format(db_session_mock):
     invalid_import_id = "invalid"
     test_event = {
         "import_id": "test.new.event.0",
@@ -53,11 +53,13 @@ def test_validate_event_when_family_import_id_wrong_format():
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_event(test_event, "test")
+        validation_service.validate_event(db_session_mock, test_event, "test")
     assert f"The import id {invalid_import_id} is invalid!" == e.value.message
 
 
-def test_validate_event_when_event_metadata_has_invalid_type(db_client_metadata_mock):
+def test_validate_event_when_event_metadata_has_invalid_type(
+    db_client_metadata_mock, db_session_mock
+):
     invalid_event_type = "invalid"
     event_metadata = {"color": invalid_event_type}
     test_event = {
@@ -73,7 +75,7 @@ def test_validate_event_when_event_metadata_has_invalid_type(db_client_metadata_
         ) as mock_event_metadata,
         pytest.raises(ValidationError) as e,
     ):
-        validation_service.validate_event(test_event, "test")
+        validation_service.validate_event(db_session_mock, test_event, "test")
     assert (
         f"Metadata validation failed: Invalid value '{invalid_event_type}' "
         "for metadata key 'color' expected list." == e.value.message
@@ -81,7 +83,9 @@ def test_validate_event_when_event_metadata_has_invalid_type(db_client_metadata_
     assert mock_event_metadata.call_count == 1
 
 
-def test_validate_event_when_event_not_in_allowed_event_types(db_client_metadata_mock):
+def test_validate_event_when_event_not_in_allowed_event_types(
+    db_client_metadata_mock, db_session_mock
+):
     invalid_event_type = ["invalid"]
     event_metadata = {"color": invalid_event_type}
     test_event = {
@@ -97,7 +101,7 @@ def test_validate_event_when_event_not_in_allowed_event_types(db_client_metadata
         ) as mock_event_metadata,
         pytest.raises(ValidationError) as e,
     ):
-        validation_service.validate_event(test_event, "test")
+        validation_service.validate_event(db_session_mock, test_event, "test")
     assert (
         f"Metadata validation failed: Invalid value '{invalid_event_type}' "
         "for metadata key 'color'" == e.value.message

--- a/tests/unit_tests/service/validation/test_event_validation.py
+++ b/tests/unit_tests/service/validation/test_event_validation.py
@@ -22,6 +22,18 @@ def test_validate_event_when_ok(db_client_metadata_mock):
     assert mock_event_metadata.call_count == 1
 
 
+def test_validate_new_event_schema_when_ok(db_client_metadata_mock):
+    test_event = {
+        "import_id": "test.new.event.0",
+        "family_import_id": "test.new.family.0",
+        "family_document_import_id": "test.new.document.0",
+        "event_type_value": "published",
+        "metadata": {"color": ["pink"]},
+    }
+
+    validation_service.validate_event(test_event, "test")
+
+
 def test_validate_event_when_import_id_wrong_format():
     invalid_import_id = "invalid"
     test_event = {

--- a/tests/unit_tests/service/validation/test_family_validation.py
+++ b/tests/unit_tests/service/validation/test_family_validation.py
@@ -4,7 +4,9 @@ import app.service.validation as validation_service
 from app.errors import ValidationError
 
 
-def test_validate_family_when_ok(corpus_repo_mock, db_client_metadata_mock):
+def test_validate_family_when_ok(
+    corpus_repo_mock, db_client_metadata_mock, db_session_mock
+):
     test_family = {
         "import_id": "test.new.family.0",
         "category": "UNFCCC",
@@ -12,21 +14,21 @@ def test_validate_family_when_ok(corpus_repo_mock, db_client_metadata_mock):
         "collections": ["test.new.collection.0"],
     }
 
-    validation_service.validate_family(test_family, "test")
+    validation_service.validate_family(db_session_mock, test_family, "test")
 
 
-def test_validate_family_when_import_id_invalid(corpus_repo_mock):
+def test_validate_family_when_import_id_invalid(corpus_repo_mock, db_session_mock):
     invalid_import_id = "invalid"
     test_family = {
         "import_id": invalid_import_id,
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_family(test_family, "test")
+        validation_service.validate_family(db_session_mock, test_family, "test")
     assert "The import id invalid is invalid!" == e.value.message
 
 
-def test_validate_family_when_corpus_invalid(corpus_repo_mock):
+def test_validate_family_when_corpus_invalid(corpus_repo_mock, db_session_mock):
     corpus_repo_mock.valid = False
 
     test_family = {
@@ -34,23 +36,25 @@ def test_validate_family_when_corpus_invalid(corpus_repo_mock):
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_family(test_family, "invalid")
+        validation_service.validate_family(db_session_mock, test_family, "invalid")
     assert "Corpus 'invalid' not found" == e.value.message
 
 
-def test_validate_family_when_category_invalid(corpus_repo_mock, geography_repo_mock):
+def test_validate_family_when_category_invalid(
+    corpus_repo_mock, geography_repo_mock, db_session_mock
+):
     test_family = {
         "import_id": "test.new.family.0",
         "category": "Test",
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_family(test_family, "test")
+        validation_service.validate_family(db_session_mock, test_family, "test")
     assert "Test is not a valid FamilyCategory" == e.value.message
 
 
 def test_validate_family_when_collection_ids_invalid(
-    corpus_repo_mock, geography_repo_mock
+    corpus_repo_mock, geography_repo_mock, db_session_mock
 ):
     test_family = {
         "import_id": "test.new.family.0",
@@ -59,12 +63,16 @@ def test_validate_family_when_collection_ids_invalid(
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_family(test_family, "test")
+        validation_service.validate_family(db_session_mock, test_family, "test")
     assert "The import ids are invalid: ['invalid']" == e.value.message
 
 
 def test_validate_family_when_metadata_not_found(
-    corpus_repo_mock, geography_repo_mock, collection_repo_mock, db_client_metadata_mock
+    corpus_repo_mock,
+    geography_repo_mock,
+    collection_repo_mock,
+    db_client_metadata_mock,
+    db_session_mock,
 ):
     db_client_metadata_mock.bad_taxonomy = True
 
@@ -76,12 +84,16 @@ def test_validate_family_when_metadata_not_found(
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_family(test_family, "test")
+        validation_service.validate_family(db_session_mock, test_family, "test")
     assert "No taxonomy found for corpus" == e.value.message
 
 
 def test_validate_family_when_metadata_invalid(
-    corpus_repo_mock, geography_repo_mock, collection_repo_mock, db_client_metadata_mock
+    corpus_repo_mock,
+    geography_repo_mock,
+    collection_repo_mock,
+    db_client_metadata_mock,
+    db_session_mock,
 ):
     test_family = {
         "import_id": "test.new.family.0",
@@ -91,5 +103,5 @@ def test_validate_family_when_metadata_invalid(
     }
 
     with pytest.raises(ValidationError) as e:
-        validation_service.validate_family(test_family, "test")
+        validation_service.validate_family(db_session_mock, test_family, "test")
     assert "Metadata validation failed: Missing metadata keys:" in e.value.message


### PR DESCRIPTION
# Description
- allow for events to have metadata already mapped
- move success notification and saving of bulk import result to s3 to after transaction commits
- add validation to check that documents referenced by events are present in the bulk import json
- move db session creation up in the validation service so that we're not getting a session to validate each individual entity

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
