### PR TITLE
Add concepts to family bulk import

### DIFF
--- a/app/model/bulk_import.py
+++ b/app/model/bulk_import.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import AnyHttpUrl, BaseModel, RootModel
 
@@ -80,6 +80,7 @@ class BulkImportFamilyDTO(BaseModel):
     metadata: Metadata
     collections: list[str]
     corpus_import_id: str
+    concepts: Optional[list[dict[str, Any]]] = []
 
     def to_family_create_dto(self, corpus_import_id: str) -> FamilyCreateDTO:
         """
@@ -97,6 +98,7 @@ class BulkImportFamilyDTO(BaseModel):
             metadata=self.metadata.model_dump(),
             collections=self.collections,
             corpus_import_id=corpus_import_id,
+            concepts=self.concepts,
         )
 
     def to_family_write_dto(self) -> FamilyWriteDTO:
@@ -112,6 +114,7 @@ class BulkImportFamilyDTO(BaseModel):
             category=self.category,
             metadata=self.metadata.model_dump(),
             collections=self.collections,
+            concepts=self.concepts,
         )
 
     def is_different_from(self, family):
@@ -125,6 +128,7 @@ class BulkImportFamilyDTO(BaseModel):
             metadata=family.metadata,
             collections=sorted(family.collections),
             corpus_import_id=family.corpus_import_id,
+            concepts=family.concepts,
         )
 
         self.collections = sorted(self.collections)

--- a/app/model/family.py
+++ b/app/model/family.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel
 
@@ -29,6 +29,7 @@ class FamilyReadDTO(BaseModel):
     corpus_type: str
     created: datetime
     last_modified: datetime
+    concepts: Optional[list[dict[str, Any]]] = []
 
 
 class FamilyWriteDTO(BaseModel):
@@ -49,6 +50,7 @@ class FamilyWriteDTO(BaseModel):
     category: str
     metadata: dict[str, list[str]]
     collections: list[str]
+    concepts: Optional[list[dict[str, Any]]] = []
 
 
 class FamilyCreateDTO(BaseModel):
@@ -70,3 +72,4 @@ class FamilyCreateDTO(BaseModel):
     metadata: dict[str, list[str]]
     collections: list[str]
     corpus_import_id: str
+    concepts: Optional[list[dict[str, Any]]] = []

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple, Union, cast
 
 from db_client.models.dfce.collection import CollectionFamily
 from db_client.models.dfce.family import (
+    Concept,
     DocumentStatus,
     Family,
     FamilyCorpus,
@@ -513,6 +514,7 @@ def create(
             title=family.title,
             description=family.summary,
             family_category=family.category,
+            concepts=[Concept(**c) for c in (family.concepts or [])],
         )
         db.add(new_family)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.18.20"
+version = "2.18.21"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/integration_tests/bulk_import/test_bulk_import.py
+++ b/tests/integration_tests/bulk_import/test_bulk_import.py
@@ -204,6 +204,40 @@ def test_bulk_import_successfully_updates_already_imported_data_when_no_error(
 
 
 @pytest.mark.s3
+def test_bulk_import_successfully_saves_families_with_concepts(
+    data_db: Session, client: TestClient, superuser_header_token
+):
+    test_concept = {
+        "id": "Federal Courts",
+        "type": "legal_entity",
+        "preferred_label": "Federal Courts",
+        "relation": "jurisdiction",
+        "subconcept_of_labels": [],
+    }
+    test_data = {
+        "collections": [default_collection],
+        "families": [
+            {
+                **default_family,
+                "concepts": [test_concept],
+            }
+        ],
+    }
+    test_input_json = build_json_file(test_data)
+
+    response = client.post(
+        "/api/v1/bulk-import/UNFCCC.corpus.i00000001.n0000",
+        files={"data": test_input_json},
+        headers=superuser_header_token,
+    )
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+
+    saved_family = data_db.query(Family).scalar()
+    assert [{**test_concept, "ids": []}] == saved_family.concepts
+
+
+@pytest.mark.s3
 def test_bulk_import_successfully_updates_document_when_user_language_has_changed(
     data_db: Session, client: TestClient, superuser_header_token
 ):

--- a/tests/integration_tests/bulk_import/test_bulk_import.py
+++ b/tests/integration_tests/bulk_import/test_bulk_import.py
@@ -209,6 +209,7 @@ def test_bulk_import_successfully_saves_families_with_concepts(
 ):
     test_concept = {
         "id": "Federal Courts",
+        "ids": [],
         "type": "legal_entity",
         "preferred_label": "Federal Courts",
         "relation": "jurisdiction",
@@ -234,7 +235,7 @@ def test_bulk_import_successfully_saves_families_with_concepts(
     assert response.status_code == status.HTTP_202_ACCEPTED
 
     saved_family = data_db.query(Family).scalar()
-    assert [{**test_concept, "ids": []}] == saved_family.concepts
+    assert [test_concept] == saved_family.concepts
 
 
 @pytest.mark.s3

--- a/tests/integration_tests/bulk_import/test_bulk_import_template.py
+++ b/tests/integration_tests/bulk_import/test_bulk_import_template.py
@@ -48,6 +48,21 @@ def test_get_template_unfccc(
                     "title": "Collections",
                     "type": "array",
                 },
+                "concepts": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "object",
+                            },
+                            "type": "array",
+                        },
+                        {
+                            "type": "null",
+                        },
+                    ],
+                    "default": [],
+                    "title": "Concepts",
+                },
             }
         ],
         "events": [

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import TypedDict, cast
+from typing import Any, Optional, TypedDict, cast
 
 from db_client.models.dfce.collection import (
     Collection,
@@ -47,6 +47,7 @@ class DBEntry(TypedDict):
     last_updated_date: str | None
     documents: list[str]
     collections: list[str]
+    concepts: Optional[list[dict[str, Any]]]
 
 
 EXPECTED_FAMILIES: list[DBEntry] = [
@@ -76,6 +77,7 @@ EXPECTED_FAMILIES: list[DBEntry] = [
         "last_updated_date": "2020-12-24T04:59:31Z",
         "documents": [],
         "collections": ["C.0.0.2"],
+        "concepts": [],
     },
     {
         "import_id": "A.0.0.2",
@@ -103,6 +105,7 @@ EXPECTED_FAMILIES: list[DBEntry] = [
         "last_updated_date": None,
         "documents": ["D.0.0.3"],
         "collections": ["C.0.0.2"],
+        "concepts": [],
     },
     {
         "import_id": "A.0.0.3",
@@ -123,6 +126,7 @@ EXPECTED_FAMILIES: list[DBEntry] = [
         "last_updated_date": "2018-12-24T04:59:33Z",
         "documents": ["D.0.0.1", "D.0.0.2"],
         "collections": ["C.0.0.4"],
+        "concepts": [],
     },
 ]
 EXPECTED_NUM_FAMILIES = len(EXPECTED_FAMILIES)

--- a/tests/unit_tests/routers/bulk_import/test_get_bulk_import_template.py
+++ b/tests/unit_tests/routers/bulk_import/test_get_bulk_import_template.py
@@ -74,6 +74,21 @@ def test_bulk_import_template_when_ok(
                     "title": "Collections",
                     "type": "array",
                 },
+                "concepts": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "object",
+                            },
+                            "type": "array",
+                        },
+                        {
+                            "type": "null",
+                        },
+                    ],
+                    "default": [],
+                    "title": "Concepts",
+                },
             }
         ],
         "events": [


### PR DESCRIPTION
# Description
- add a concept field to the BulkImport and Family DTOs so that we can bulk import/update concepts on families

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [x] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
