### PR TITLE
add function to close db connections via context manager

### DIFF
--- a/app/clients/db/session.py
+++ b/app/clients/db/session.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import contextmanager
 
 from sqlalchemy import create_engine, exc
 from sqlalchemy.orm import Session, sessionmaker
@@ -23,6 +24,15 @@ engine = create_engine(
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@contextmanager
+def get_db_session():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 def get_db() -> Session:

--- a/app/repository/family.py
+++ b/app/repository/family.py
@@ -119,6 +119,9 @@ def _family_to_dto_search_endpoint(db: Session, family_row: dict) -> FamilyReadD
     family_slugs = family_row["slugs"]
     event_ids = family_row["event_ids"] if family_row["event_ids"] else []
     document_ids = family_row["document_ids"] if family_row["document_ids"] else []
+    collection_ids = (
+        family_row["collection_ids"] if family_row["collection_ids"] else []
+    )
 
     return FamilyReadDTO(
         import_id=str(family_import_id),
@@ -136,12 +139,7 @@ def _family_to_dto_search_endpoint(db: Session, family_row: dict) -> FamilyReadD
         published_date=family_row["published_date"],
         last_updated_date=family_row["last_updated_date"],
         documents=document_ids,
-        collections=[
-            c.collection_import_id
-            for c in db.query(CollectionFamily).filter(
-                family_import_id == CollectionFamily.family_import_id
-            )
-        ],
+        collections=collection_ids,
         organisation=org,
         corpus_import_id=family_row["corpus_import_id"],
         corpus_title=cast(str, family_row["title"]),

--- a/app/service/family.py
+++ b/app/service/family.py
@@ -82,7 +82,7 @@ def search(
     :return list[FamilyDTO]: The list of families matching the given
         search terms.
     """
-    with db_session.get_db() as db:
+    with db_session.get_db_session() as db:
         org_id = app_user.restrict_entities_to_user_org(user)
         return family_repo.search(db, search_params, org_id, geography)
 


### PR DESCRIPTION


# Description



Two Things 

Issue 2 - The collections sub query 


N+1 Query Problem: For each family returned by the search, we're making an additional database query to fetch its collections. This means if your search returns 100 families, you'll have 1 main query + 100 additional queries to get collections. This is a classic N+1 query anti-pattern that can severely impact performance.

No Limit on Results: The collection query doesn't have any limit, so for each family, it will fetch all associated collections. While this might be fine for families with few collections, it could be problematic for families with many collections.

Separate Transaction: Each collection query runs in a separate database round trip, which adds network latency for each family.


Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
