### PR TITLE
fix: dispose of db engine on lifecycle shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY ./tests ./tests
 
 EXPOSE 8888
 
-CMD python app/main.py
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8888"]


### PR DESCRIPTION
# Description
- runs fastapi via the uvicorn method
- this ensure the lifecycle of the app is adhered to

I would like to then redeploy the app to make sure connections are being disposed of properly.