### PR TITLE
fix: create latest tag before trying to push it

### DIFF
--- a/.github/workflows/merge-to-main.yml
+++ b/.github/workflows/merge-to-main.yml
@@ -62,5 +62,6 @@ jobs:
         run: |
           docker tag navigator-admin-backend $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag navigator-admin-backend $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Description

- tags the ECR image before it pushes it ([which is currently broken](https://github.com/climatepolicyradar/navigator-admin-backend/actions/runs/16724983534/job/47338118947))