### PR TITLE
Remove document limit from bulk import

### DIFF
--- a/app/api/api_v1/routers/bulk_import.py
+++ b/app/api/api_v1/routers/bulk_import.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, UploadFile, status
 
@@ -56,7 +55,6 @@ async def bulk_import(
     data: UploadFile,
     corpus_import_id: str,
     background_tasks: BackgroundTasks,
-    document_limit: Optional[int] = None,
 ) -> Json:
     """
     Bulk import endpoint.
@@ -64,7 +62,6 @@ async def bulk_import(
     :param UploadFile data: File containing json representation of data to import.
     :param str corpus_import_id: The ID of the corpus to import.
     :param BackgroundTasks background_tasks: Background tasks to be performed after the request is completed.
-    :param Optional[int] document_limit: The max number of documents to be saved in this session or None.
     :return Json: json representation of the data to import.
     """
     try:
@@ -79,9 +76,7 @@ async def bulk_import(
 
         _LOGGER.info("✅ Validation successful")
 
-        background_tasks.add_task(
-            import_data, data_dict, corpus_import_id, document_limit
-        )
+        background_tasks.add_task(import_data, data_dict, corpus_import_id)
 
         return {
             "message": "Bulk import request accepted. Check Cloudwatch logs for result."

--- a/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
+++ b/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
@@ -194,38 +194,8 @@ def test_save_documents_when_data_invalid(validation_service_mock):
     test_data = [{"import_id": "invalid"}]
 
     with pytest.raises(ValidationError) as e:
-        bulk_import_service.save_documents(test_data, "test", 1)
+        bulk_import_service.save_documents(test_data, "test")
     assert "Error" == e.value.message
-
-
-@patch("app.service.bulk_import.generate_slug", Mock(return_value="test-slug_1234"))
-def test_do_not_save_documents_over_bulk_import_limit(
-    validation_service_mock, document_repo_mock, monkeypatch
-):
-    document_repo_mock.return_empty = True
-    test_data = [
-        {
-            "import_id": "test.new.document.0",
-            "family_import_id": "test.new.family.0",
-            "variant_name": "Original Language",
-            "metadata": {"color": ["blue"]},
-            "title": "",
-            "source_url": None,
-            "user_language_name": "",
-        },
-        {
-            "import_id": "test.new.document.1",
-            "family_import_id": "test.new.family.1",
-            "variant_name": "Original Language",
-            "metadata": {"color": ["blue"]},
-            "title": "",
-            "source_url": None,
-            "user_language_name": "",
-        },
-    ]
-
-    saved_documents = bulk_import_service.save_documents(test_data, "test", 1)
-    assert ["test.new.document.0"] == saved_documents
 
 
 def test_save_events_with_correct_metadata(validation_service_mock, event_repo_mock):
@@ -321,9 +291,7 @@ def test_save_documents_skips_update_when_no_changes(
         }
     ]
 
-    result = bulk_import_service.save_documents(
-        test_data, "test_corpus_id", document_limit=1
-    )
+    result = bulk_import_service.save_documents(test_data, "test_corpus_id")
 
     assert document_repo_mock.update.call_count == 0
     assert result == []


### PR DESCRIPTION
# Description

- remove the arbitrary document limit of 1000 docs for a single bulk import as it no longer applies

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
