### PR TITLE
Feature/app 1240 avoid unnecessary metadata updates on bulk import

### DIFF
--- a/app/model/bulk_import.py
+++ b/app/model/bulk_import.py
@@ -2,18 +2,33 @@ import logging
 import os
 from datetime import datetime
 from pprint import pformat
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
-from pydantic import AnyHttpUrl, BaseModel, RootModel
+from pydantic import AnyHttpUrl, BaseModel, RootModel, model_validator
 
 from app.model.collection import CollectionCreateDTO, CollectionWriteDTO
 from app.model.document import DocumentCreateDTO, DocumentWriteDTO
 from app.model.event import EventCreateDTO, EventWriteDTO
 from app.model.family import FamilyCreateDTO, FamilyWriteDTO
 
-Metadata = RootModel[Dict[str, Union[str, List[str]]]]
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
+
+
+class Metadata(RootModel[dict[str, Union[str, list[str]]]]):
+    @model_validator(mode="after")
+    def _normalize(self) -> "Metadata":
+        normalized: dict[str, Union[str, list[str]]] = {}
+        for key in sorted(
+            self.root.keys()
+        ):  # remove sorted(...) if you only care about equality
+            value = self.root[key]
+            if isinstance(value, list):
+                normalized[key] = sorted(value)
+            else:
+                normalized[key] = value
+        self.root = normalized
+        return self
 
 
 class BulkImportCollectionDTO(BaseModel):

--- a/app/model/bulk_import.py
+++ b/app/model/bulk_import.py
@@ -17,17 +17,15 @@ _LOGGER.setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
 
 class Metadata(RootModel[dict[str, Union[str, list[str]]]]):
     @model_validator(mode="after")
-    def _normalize(self) -> "Metadata":
-        normalized: dict[str, Union[str, list[str]]] = {}
-        for key in sorted(
-            self.root.keys()
-        ):  # remove sorted(...) if you only care about equality
+    def _sort(self) -> "Metadata":
+        ordered: dict[str, Union[str, list[str]]] = {}
+        for key in self.root.keys():
             value = self.root[key]
             if isinstance(value, list):
-                normalized[key] = sorted(value)
+                ordered[key] = sorted(value)
             else:
-                normalized[key] = value
-        self.root = normalized
+                ordered[key] = value
+        self.root = ordered
         return self
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "admin_backend"
-version = "2.21.4"
+version = "2.21.5"
 description = ""
 authors = ["CPR-dev-team <tech@climatepolicyradar.org>"]
 packages = [{ include = "app" }, { include = "tests" }]

--- a/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
+++ b/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
@@ -277,6 +277,36 @@ def test_save_families_skips_update_when_no_changes(
     assert result == []
 
 
+@patch("app.service.bulk_import.family_repository.update")
+@patch("app.service.bulk_import.family_repository.get")
+def test_save_families_skips_update_when_no_changes_to_metadata_regardless_of_ordering(
+    mock_get,
+    mock_update,
+    corpus_repo_mock,
+    geography_repo_mock,
+    validation_service_mock,
+):
+    saved_metadata = {"A": [""], "B": [""], "C": [""]}
+    saved_family = {
+        "import_id": "test.new.family.1000",
+        "title": "title",
+        "summary": "summary",
+        "geographies": ["XAA"],
+        "category": "Test",
+        "metadata": saved_metadata,
+        "collections": [],
+    }
+    mock_get.return_value = saved_family
+
+    metadata_different_order = {"C": [], "A": [], "B": []}
+    new_family = {**saved_family, "metadata": metadata_different_order}
+
+    result = bulk_import_service.save_families([new_family], "test.corpus.0.n0000")
+
+    assert mock_update.call_count == 0
+    assert result == []
+
+
 def test_save_documents_skips_update_when_no_changes(
     document_repo_mock, corpus_repo_mock, validation_service_mock
 ):

--- a/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
+++ b/tests/unit_tests/service/bulk_import/test_bulk_import_service.py
@@ -339,6 +339,79 @@ def test_save_families_skips_update_when_no_changes_to_metadata_regardless_of_or
     assert result == []
 
 
+@patch("app.service.bulk_import.family_repository.update")
+@patch("app.service.bulk_import.family_repository.get")
+def test_save_families_skips_update_when_no_changes_to_concepts_regardless_of_ordering(
+    mock_get,
+    mock_update,
+    corpus_repo_mock,
+    geography_repo_mock,
+    validation_service_mock,
+):
+    corpus_import_id = "test.corpus.0.n0000"
+    saved_concepts = [
+        {"id": "a", "relation": "1"},
+        {"id": "b", "relation": "2"},
+        {"id": "c", "relation": "2"},
+        {"id": "d", "relation": "3"},
+    ]
+    saved_family = {
+        "import_id": "test.new.family.1000",
+        "title": "title",
+        "summary": "summary",
+        "geographies": ["XAA"],
+        "category": "Test",
+        "metadata": {},
+        "collections": [],
+        "concepts": saved_concepts,
+    }
+
+    saved_family_dto = FamilyReadDTO(
+        import_id=saved_family["import_id"],
+        title=saved_family["title"],
+        summary=saved_family["summary"],
+        geographies=saved_family["geographies"],
+        category=saved_family["category"],
+        metadata={},
+        collections=saved_family["collections"],
+        status="",
+        slug="",
+        events=[],
+        documents=[],
+        published_date=None,
+        last_updated_date=None,
+        created=datetime.now(),
+        last_modified=datetime.now(),
+        organisation="",
+        corpus_import_id=corpus_import_id,
+        corpus_title="",
+        corpus_type="",
+        concepts=saved_concepts,
+    )
+    mock_get.return_value = saved_family_dto
+
+    concepts_different_order = [
+        {"id": "d", "relation": "3"},
+        {"id": "c", "relation": "2"},
+        {"id": "a", "relation": "1"},
+        {"id": "b", "relation": "2"},
+    ]
+    new_family = {
+        "import_id": "test.new.family.1000",
+        "title": "title",
+        "summary": "summary",
+        "geographies": ["XAA"],
+        "category": "Test",
+        "metadata": {},
+        "collections": [],
+        "concepts": concepts_different_order,
+    }
+    result = bulk_import_service.save_families([new_family], corpus_import_id)
+
+    assert mock_update.call_count == 0
+    assert result == []
+
+
 def test_save_documents_skips_update_when_no_changes(
     document_repo_mock, corpus_repo_mock, validation_service_mock
 ):


### PR DESCRIPTION
# Description

- extend the bulk import metadata model so that it automatically sorts its own values if they are a list
- add missing test for sorting concepts

This is so that we avoid unnecessarily updating families in the DB if only the order in the list has changed.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
