### PR TITLE
feat: surface the attribution urls on the corpus endpoint

### DIFF
--- a/app/model/corpus.py
+++ b/app/model/corpus.py
@@ -19,6 +19,7 @@ class CorpusReadDTO(BaseModel):
     corpus_type_name: str
     corpus_type_description: str
     metadata: Json
+    attribution_url: Optional[str] = None
 
     # TODO: Add create and last modified timestamps.
 
@@ -32,6 +33,7 @@ class CorpusWriteDTO(BaseModel):
     corpus_image_url: Optional[str]
 
     corpus_type_description: str
+    attribution_url: Optional[str] = None
 
 
 class CorpusCreateDTO(BaseModel):
@@ -44,6 +46,7 @@ class CorpusCreateDTO(BaseModel):
     corpus_image_url: Optional[str]
     organisation_id: int
     corpus_type_name: str
+    attribution_url: Optional[str] = None
 
 
 class CorpusLogoUploadDTO(BaseModel):

--- a/app/repository/corpus.py
+++ b/app/repository/corpus.py
@@ -52,6 +52,11 @@ def _corpus_to_dto(
         corpus_type_description=cast(str, corpus_type.description),
         organisation_id=cast(int, org.id),
         organisation_name=cast(str, org.name),
+        attribution_url=(
+            cast(str, corpus.attribution_url)
+            if corpus.attribution_url is not None and corpus.attribution_url != ""
+            else None
+        ),
         # TODO add created and last modified timestamps?
     )
 
@@ -215,6 +220,9 @@ def update(db: Session, import_id: str, corpus: CorpusWriteDTO) -> bool:
     image_url_has_changed = original_corpus.corpus_image_url != cast(
         str, new_values["corpus_image_url"]
     )
+    attribution_url_has_changed = original_corpus.attribution_url != (
+        cast(str, new_values["attribution_url"])
+    )
 
     if not any(
         [
@@ -223,6 +231,7 @@ def update(db: Session, import_id: str, corpus: CorpusWriteDTO) -> bool:
             description_has_changed,
             corpus_text_has_changed,
             image_url_has_changed,
+            attribution_url_has_changed,
         ]
     ):
         return True
@@ -245,6 +254,7 @@ def update(db: Session, import_id: str, corpus: CorpusWriteDTO) -> bool:
             title_has_changed,
             description_has_changed,
             image_url_has_changed,
+            attribution_url_has_changed,
         ]
     ):
         commands.append(
@@ -259,6 +269,11 @@ def update(db: Session, import_id: str, corpus: CorpusWriteDTO) -> bool:
                     else None
                 ),
                 corpus_text=new_values["corpus_text"],
+                attribution_url=(
+                    str(new_values["attribution_url"])
+                    if new_values["attribution_url"] is not None
+                    else None
+                ),
             ),
         )
 
@@ -294,6 +309,7 @@ def create(db: Session, corpus: CorpusCreateDTO) -> str:
             corpus_image_url=corpus.corpus_image_url,
             organisation_id=corpus.organisation_id,
             corpus_type_name=corpus.corpus_type_name,
+            attribution_url=corpus.attribution_url,
         )
         db.add(new_corpus)
         db.flush()

--- a/tests/helpers/corpus.py
+++ b/tests/helpers/corpus.py
@@ -9,6 +9,7 @@ def create_corpus_write_dto(
     description: Optional[str] = "description",
     image_url: Optional[str] = "some-picture.png",
     corpus_type_description: str = "some description",
+    attribution_url: Optional[str] = None,
 ) -> CorpusWriteDTO:
     return CorpusWriteDTO(
         title=title,
@@ -16,6 +17,7 @@ def create_corpus_write_dto(
         corpus_text=corpus_text,
         corpus_image_url=image_url,
         corpus_type_description=corpus_type_description,
+        attribution_url=attribution_url,
     )
 
 
@@ -27,6 +29,7 @@ def create_corpus_create_dto(
     image_url: Optional[str] = "some-picture.png",
     org_id: int = 1,
     import_id: Optional[str] = None,
+    attribution_url: Optional[str] = None,
 ) -> CorpusCreateDTO:
     return CorpusCreateDTO(
         import_id=import_id,
@@ -36,4 +39,5 @@ def create_corpus_create_dto(
         corpus_image_url=image_url,
         organisation_id=org_id,
         corpus_type_name=corpus_type,
+        attribution_url=attribution_url,
     )

--- a/tests/integration_tests/corpus/test_create.py
+++ b/tests/integration_tests/corpus/test_create.py
@@ -102,6 +102,39 @@ def test_create_corpus_allows_none_corpus_image_url(
     assert ct > 1
 
 
+def test_create_corpus_allows_none_attribution_url(
+    client: TestClient, data_db: Session, superuser_header_token
+):
+    setup_db(data_db)
+    new_corpus = create_corpus_create_dto("Laws and Policies", attribution_url=None)
+    response = client.post(
+        "/api/v1/corpora",
+        json=new_corpus.model_dump(),
+        headers=superuser_header_token,
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+    data = response.json()
+    assert data == "CCLW.corpus.i00000002.n0000"
+    actual_corpus = data_db.query(Corpus).filter(Corpus.import_id == data).one()
+
+    assert actual_corpus.import_id == "CCLW.corpus.i00000002.n0000"
+    assert actual_corpus.title == "title"
+    assert actual_corpus.description == "description"
+    assert actual_corpus.corpus_text == "corpus_text"
+    assert actual_corpus.corpus_type_name == "Laws and Policies"
+    assert actual_corpus.corpus_image_url == "some-picture.png"
+    assert actual_corpus.attribution_url is None
+    assert actual_corpus.organisation_id == 1
+
+    ct: int = (
+        data_db.query(Corpus)
+        .filter(Corpus.corpus_type_name == "Laws and Policies")
+        .count()
+    )
+    assert ct > 1
+
+
 def test_create_corpus_when_corpus_type_not_exist(
     client: TestClient, data_db: Session, superuser_header_token
 ):

--- a/tests/integration_tests/corpus/test_update.py
+++ b/tests/integration_tests/corpus/test_update.py
@@ -149,6 +149,66 @@ def test_update_corpus_allows_none_corpus_description(
     assert ct.valid_metadata == old_ct.valid_metadata
 
 
+def test_update_corpus_allows_none_attribution_url(
+    client: TestClient, data_db: Session, superuser_header_token
+):
+    setup_db(data_db)
+    old_ct = (
+        data_db.query(CorpusType).filter(CorpusType.name == "Laws and Policies").one()
+    )
+    new_corpus = create_corpus_write_dto(attribution_url=None)
+    response = client.put(
+        "/api/v1/corpora/CCLW.corpus.i00000001.n0000",
+        json=new_corpus.model_dump(),
+        headers=superuser_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["organisation_id"] == 1
+    assert data["organisation_name"] == "CCLW"
+    assert data["corpus_type_name"] == old_ct.name
+
+    db_corpus: Corpus = (
+        data_db.query(Corpus)
+        .filter(Corpus.import_id == "CCLW.corpus.i00000001.n0000")
+        .one()
+    )
+    assert db_corpus.attribution_url is None
+
+
+def test_updates_corpus_attribution_url(
+    client: TestClient, data_db: Session, superuser_header_token
+):
+    setup_db(data_db)
+    old_ct = (
+        data_db.query(CorpusType).filter(CorpusType.name == "Laws and Policies").one()
+    )
+    new_corpus = create_corpus_write_dto(
+        attribution_url="http://new-attribution-url.com"
+    )
+    response = client.put(
+        "/api/v1/corpora/CCLW.corpus.i00000001.n0000",
+        json=new_corpus.model_dump(),
+        headers=superuser_header_token,
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["organisation_id"] == 1
+    assert data["organisation_name"] == "CCLW"
+    assert data["corpus_type_name"] == old_ct.name
+
+    breakpoint()
+
+    assert data["attribution_url"] == "http://new-attribution-url.com"
+
+    db_corpus: Corpus = (
+        data_db.query(Corpus)
+        .filter(Corpus.import_id == "CCLW.corpus.i00000001.n0000")
+        .one()
+    )
+    assert db_corpus.attribution_url == "http://new-attribution-url.com"
+
+
 def test_update_corpus_when_not_authorised(client: TestClient, data_db: Session):
     setup_db(data_db)
     new_corpus = create_corpus_write_dto()

--- a/tests/integration_tests/setup_db.py
+++ b/tests/integration_tests/setup_db.py
@@ -298,6 +298,7 @@ EXPECTED_CCLW_CORPUS = {
     "organisation_name": "CCLW",
     "corpus_type_name": "Laws and Policies",
     "corpus_type_description": "Laws and policies",
+    "attribution_url": None,
 }
 EXPECTED_UNFCCC_CORPUS = {
     "import_id": "UNFCCC.corpus.i00000001.n0000",
@@ -314,6 +315,7 @@ EXPECTED_UNFCCC_CORPUS = {
     "organisation_name": "UNFCCC",
     "corpus_type_name": "Intl. agreements",
     "corpus_type_description": "Intl. agreements",
+    "attribution_url": None,
 }
 EXPECTED_CORPORA_KEYS = [
     "import_id",
@@ -326,6 +328,7 @@ EXPECTED_CORPORA_KEYS = [
     "corpus_type_name",
     "corpus_type_description",
     "metadata",
+    "attribution_url",
 ]
 
 EXPECTED_NUM_ORGS = 3


### PR DESCRIPTION
# Description

Please include:

Surface the attribution url on all the applicable corpus endpoints

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
