### PR TITLE
Fix tests so unit tests don't run against Docker

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,15 +35,10 @@ jobs:
       ! startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - name: Install latest Docker Compose
-        uses: ndeloof/install-compose-action@v0.0.1
-        with:
-          legacy: false
-
       - uses: actions/checkout@v6
 
       - name: Run Unit Tests
-        run: make test TEST=tests/unit_tests/
+        run: make unit_tests
         env:
           POSTGRES_USER: navigator_admin
           POSTGRES_PASSWORD: password
@@ -63,7 +58,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run Integration Tests
-        run: make test TEST=tests/integration_tests
+        run: make integration_tests
         env:
           POSTGRES_USER: navigator_admin
           POSTGRES_PASSWORD: password

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,6 +36,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - uses: Gr1N/setup-poetry@v9
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+
+      - name: Install dependencies
+        run: poetry install
 
       - name: Run Unit Tests
         run: make unit_tests

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,27 @@ dev_rds_dump_update:
 
 
 # --- Test --- #
-# If you'd like to run more specific, you can run e.g.
-# - `make test TEST=tests/integration_tests`
-# - `make test TEST=tests/unit_tests`
-# - `make test TEST=tests/integration_tests/ingest/test_ingest.py::test_ingest_when_ok`
-#
-# We've left it specifically unprefixed so autocomplete works in the terminal
-override TEST ?=
+# Run only unit tests (without Docker):
+# - `make unit_tests`
+# - `make unit_tests UNIT_TEST=tests/unit_tests/routers/ingest/test_bulk_ingest.py`
+# - `make unit_tests UNIT_TEST='tests/unit_tests -k bulk_ingest'`
+UNIT_TEST ?=tests/unit_tests/
+
+# Run only integration tests (with Docker):
+# - `make integration_tests`
+# - `make integration_tests INTEGRATION_TEST=tests/integration_tests/collection`
+# - `make integration_tests INTEGRATION_TEST='tests/integration_tests -k update'`
+INTEGRATION_TEST ?=tests/integration_tests
+
 test:
-	TEST=$(TEST) docker-compose -f docker-compose-test.yml run --rm webapp
+	$(MAKE) unit_tests UNIT_TEST="$(UNIT_TEST)"
+	$(MAKE) integration_tests INTEGRATION_TEST="$(INTEGRATION_TEST)"
+
+unit_tests:
+	poetry run pytest --disable-warnings -vvv $(UNIT_TEST)
+
+integration_tests:
+	TEST="$(INTEGRATION_TEST)" docker-compose -f docker-compose-test.yml run --rm webapp
 
 # --- CI --- #
 build:

--- a/README.md
+++ b/README.md
@@ -31,23 +31,34 @@ To get a running version of the API on
     make dev
 ```
 
-To run the test suite run:
+To run the full test suite run:
 
 ```shell
     make test
 ```
 
-To run a specific test suite run:
+To run unit tests without Docker run:
 
 ```shell
-    # a specific suite
-    make test TEST=tests/unit_tests/
+    make unit_tests
 
-    # a spcific file
-    make test TEST=tests/unit_tests/routers/ingest/test_bulk_ingest.py
+    # a specific file
+    make unit_tests UNIT_TEST=tests/unit_tests/routers/ingest/test_bulk_ingest.py
 
-    # a specific function
-    make test TEST=tests/unit_tests/routers/ingest/test_bulk_ingest.py::test_bulk_ingest
+    # a specific function / expression
+    make unit_tests UNIT_TEST='tests/unit_tests/routers/ingest/test_bulk_ingest.py::test_bulk_ingest -k bulk_ingest'
+```
+
+To run integration tests (Docker) run:
+
+```shell
+    make integration_tests
+
+    # a specific suite/file
+    make integration_tests INTEGRATION_TEST=tests/integration_tests/collection
+
+    # a specific function / expression
+    make integration_tests INTEGRATION_TEST='tests/integration_tests/collection/test_update.py::test_update_collection -k update'
 ```
 
 ## Background

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -16,6 +16,9 @@ from botocore.exceptions import ClientError
 from fastapi.testclient import TestClient
 from moto import mock_aws
 
+# Ensure token service imports do not fail during test collection.
+os.environ.setdefault("SECRET_KEY", "unit-test-secret-key")
+
 import app.service.analytics as analytics_service
 import app.service.app_user as app_user_service
 import app.service.bulk_import as bulk_import_service


### PR DESCRIPTION
# Description

- Add new makefile commands to run unit tests and integration tests separately
- Update make test command so that we don't run unit tests against Docker (as they should be independent of the database)
- Use the new makefile commands in the GHA workflow in CI

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
