### PR TITLE
Add a ecsdeploy to the GA prod deploy workflow and update schedule

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,7 +1,7 @@
 name: Deploy admin backend to production
 on:
   workflow_dispatch: {}
-  # Mon-Thur 09:00 & 12:00
+  # Mon-Thur 11:30
   schedule:
     - cron: 30 11 * * 1-4
 permissions:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: {}
   # Mon-Thur 09:00 & 12:00
   schedule:
-    - cron: 0 9,12 * * 1-5
+    - cron: 30 11 * * 1-4
 permissions:
   id-token: write
   contents: read
@@ -35,3 +35,10 @@ jobs:
           docker tag navigator-admin-backend $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Redeploy ECS service (production)
+        run: |
+          aws --region eu-west-1 ecs update-service \
+            --cluster admin-backend-production \
+            --service admin-backend-production \
+            --force-new-deployment


### PR DESCRIPTION
# Description

Updates the `deploy-production` workflow:
- changes daily deploy schedule to 11:30 Mon-Thu
- adds a deployment of the ECS service

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
