### PR TITLE
Migrate old org_id to org_ids

### DIFF
--- a/app/api/api_v1/routers/collection.py
+++ b/app/api/api_v1/routers/collection.py
@@ -170,7 +170,8 @@ async def create_collection(
     :return str: returns the import_id of the new collection.
     """
     try:
-        return collection_service.create(new_collection, request.state.user.org_id)
+        org_id = new_collection.org_id or request.state.user.org_id
+        return collection_service.create(new_collection, org_id)
     except ValidationError as e:
         _LOGGER.error(e.message)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.message)

--- a/app/model/collection.py
+++ b/app/model/collection.py
@@ -36,3 +36,4 @@ class CollectionCreateDTO(BaseModel):
     title: str
     description: str
     metadata: Optional[Json] = {}
+    org_id: Optional[int] = None

--- a/app/model/user.py
+++ b/app/model/user.py
@@ -7,7 +7,7 @@ class UserContext(BaseModel):
     """An object representing what is in the token."""
 
     email: str
-    org_id: int
+    org_id: Optional[int] = None
     org_ids: list[int] = []
     is_superuser: bool = False
     authorisation: Optional[Mapping[str, Any]] = None

--- a/app/repository/app_user.py
+++ b/app/repository/app_user.py
@@ -94,18 +94,5 @@ def update_org_memberships(
                 is_admin=org.is_admin,
             )
         )
+
     db.flush()
-
-
-def get_org_id(db: Session, user_email: str) -> Optional[int]:
-    """Gets the organisation id given the user's email"""
-    result = (
-        db.query(Organisation.id)
-        .select_from(Organisation)
-        .join(OrganisationUser, Organisation.id == OrganisationUser.organisation_id)
-        .join(AppUser, AppUser.email == user_email)
-        .filter(AppUser.email == OrganisationUser.appuser_email)
-        .scalar()
-    )
-    if result is not None:
-        return cast(int, result)

--- a/app/repository/config.py
+++ b/app/repository/config.py
@@ -91,7 +91,7 @@ def get_corpora(db: Session, user: UserContext) -> Sequence[CorpusData]:
     if user.is_superuser:
         corpora = corpora.all()
     else:
-        corpora = corpora.filter(Organisation.id == user.org_id).all()
+        corpora = corpora.filter(Organisation.id.in_(user.org_ids)).all()
 
     corpus_data_list = []
     for row in corpora:

--- a/app/service/app_user.py
+++ b/app/service/app_user.py
@@ -22,7 +22,7 @@ def is_superuser(db: Session, user: UserContext) -> bool:
 def restrict_entities_to_user_org(user: UserContext) -> Optional[list[int]]:
     if user.is_superuser:
         return None
-    return user.org_ids or [user.org_id]
+    return user.org_ids
 
 
 def all_users() -> list[UserReadDTO]:
@@ -71,7 +71,7 @@ def raise_if_unauthorised_to_make_changes(
     if user.is_superuser:
         return True
 
-    accessible = restrict_entities_to_user_org(user) or [user.org_id]
+    accessible = restrict_entities_to_user_org(user) or []
     if entity_org_id not in accessible:
         msg = f"User '{user.email}' is not authorised to perform operation on '{import_id}'"
         _LOGGER.error(msg)

--- a/app/service/authentication.py
+++ b/app/service/authentication.py
@@ -46,7 +46,6 @@ def authenticate_user(email: str, password: str) -> str:
     :return str: The JWT token.
     """
 
-    org_id = None
     with db_session.get_db() as db:
         try:
             user = app_user_repo.get_user_by_email(db, email)
@@ -60,17 +59,16 @@ def authenticate_user(email: str, password: str) -> str:
             _LOGGER.error(f"Failed login attempt as inactive for {email}")
             raise AuthenticationError(f"User {email} is marked as not active.")
 
-        org_id = app_user_repo.get_org_id(db, cast(str, user.email))
-        if org_id is None:
-            _LOGGER.error(f"Failed login attempt, org not found for {email}")
-            raise RepositoryError(f"Organisation not found for {email}")
-
         hash = str(user.hashed_password)
         if len(hash) == 0 or not verify_password(password, hash):
             _LOGGER.error(f"Failed login attempt for password mismatch for {email}")
             raise AuthenticationError(f"Could not verify password for {email}")
 
         app_user_links = app_user_repo.get_app_user_authorisation(db, user)
+
+    if not app_user_links:
+        _LOGGER.error(f"Failed login attempt, no orgs found for {email}")
+        raise RepositoryError(f"Organisation not found for {email}")
 
     authorisation = {
         cast(str, org.name): {
@@ -83,5 +81,5 @@ def authenticate_user(email: str, password: str) -> str:
     org_ids = [cast(int, org.id) for _, org in app_user_links]
 
     return token_service.encode(
-        email, org_id, cast(bool, user.is_superuser), authorisation, org_ids=org_ids
+        email, cast(bool, user.is_superuser), authorisation, org_ids=org_ids
     )

--- a/app/service/token.py
+++ b/app/service/token.py
@@ -17,7 +17,6 @@ _LOGGER = logging.getLogger(__name__)
 
 def encode(
     email: str,
-    org_id: int,
     is_superuser: bool,
     authorisation: dict,
     minutes: Optional[int] = None,
@@ -30,6 +29,7 @@ def encode(
     :param bool is_superuser: User's ability to be a superuser.
     :param dict authorisation: Authorisation information (not yet fully spec'd)
     :param Optional[int] minutes: TTL for the token
+    :param Optional[list[int]] org_ids: All organisation IDs the user belongs to
     :return str: The encoded token
     """
 
@@ -44,16 +44,15 @@ def encode(
     if not isinstance(is_superuser, bool):
         raise TokenError(f"Parameter is_superuser should be a bool, not {is_superuser}")
 
-    if not isinstance(org_id, int):
-        raise TokenError(f"Parameter org_id should be an int, not {org_id}")
-
+    resolved_org_ids = org_ids or []
     to_encode = {
         "sub": email,
         "email": email,
         "is_superuser": is_superuser,
         "authorisation": authorisation,
-        "org_id": org_id,
-        "org_ids": org_ids if org_ids is not None else [org_id],
+        "org_ids": resolved_org_ids,
+        # org_id kept for backward compat with existing tokens
+        "org_id": resolved_org_ids[0] if resolved_org_ids else None,
     }
     expiry_minutes = minutes or ACCESS_TOKEN_EXPIRE_MINUTES
     expire = datetime.utcnow() + timedelta(minutes=expiry_minutes)
@@ -85,15 +84,17 @@ def decode(token: str) -> UserContext:
 
     authorisation: Optional[dict[str, Any]] = payload.get("authorisation", {})
 
-    org_id = payload.get("org_id")
-    if org_id is None or not isinstance(org_id, int):
-        raise TokenError("Token did not contain an organisation_id")
+    org_id: Optional[int] = payload.get("org_id")
+    org_ids: list[int] = payload.get("org_ids") or (
+        [org_id] if org_id is not None else []
+    )
 
-    org_ids: list[int] = payload.get("org_ids") or [org_id]
+    if not org_ids:
+        raise TokenError("Token did not contain any organisation_id")
 
     jwt_user = UserContext(
         email=email,
-        org_id=org_id,
+        org_id=org_ids[0],
         org_ids=org_ids,
         is_superuser=payload.get("is_superuser", False),
         authorisation=authorisation,

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -241,7 +241,7 @@ def rollback_organisation_repo(monkeypatch, mocker):
 @pytest.fixture
 def superuser_header_token() -> Dict[str, str]:
     a_token = token_service.encode(
-        "super@cpr.org", SUPER_ORG_ID, True, {"is_admin": True}
+        "super@cpr.org", True, {"is_admin": True}, org_ids=[SUPER_ORG_ID]
     )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
@@ -249,7 +249,9 @@ def superuser_header_token() -> Dict[str, str]:
 
 @pytest.fixture
 def non_admin_superuser_header_token() -> Dict[str, str]:
-    a_token = token_service.encode("non-admin-super@cpr.org", SUPER_ORG_ID, True, {})
+    a_token = token_service.encode(
+        "non-admin-super@cpr.org", True, {}, org_ids=[SUPER_ORG_ID]
+    )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
 
@@ -257,7 +259,7 @@ def non_admin_superuser_header_token() -> Dict[str, str]:
 @pytest.fixture
 def user_header_token() -> Dict[str, str]:
     a_token = token_service.encode(
-        "cclw@cpr.org", CCLW_ORG_ID, False, {"is_admin": False}
+        "cclw@cpr.org", False, {"is_admin": False}, org_ids=[CCLW_ORG_ID]
     )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
@@ -266,7 +268,7 @@ def user_header_token() -> Dict[str, str]:
 @pytest.fixture
 def admin_user_header_token() -> Dict[str, str]:
     a_token = token_service.encode(
-        "admin@cpr.org", CCLW_ORG_ID, False, {"is_admin": True}
+        "admin@cpr.org", False, {"is_admin": True}, org_ids=[CCLW_ORG_ID]
     )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
@@ -275,7 +277,7 @@ def admin_user_header_token() -> Dict[str, str]:
 @pytest.fixture
 def non_cclw_user_header_token() -> Dict[str, str]:
     a_token = token_service.encode(
-        "unfccc@cpr.org", UNFCCC_ORG_ID, False, {"is_admin": False}
+        "unfccc@cpr.org", False, {"is_admin": False}, org_ids=[UNFCCC_ORG_ID]
     )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
@@ -283,7 +285,9 @@ def non_cclw_user_header_token() -> Dict[str, str]:
 
 @pytest.fixture
 def invalid_user_header_token() -> Dict[str, str]:
-    a_token = token_service.encode("non-admin@cpr.org", CCLW_ORG_ID, False, {})
+    a_token = token_service.encode(
+        "non-admin@cpr.org", False, {}, org_ids=[CCLW_ORG_ID]
+    )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
 

--- a/tests/mocks/repos/app_user_repo.py
+++ b/tests/mocks/repos/app_user_repo.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+from unittest.mock import MagicMock
 
 from db_client.models.organisation.users import AppUser, Organisation, OrganisationUser
 from pytest import MonkeyPatch
@@ -23,7 +24,15 @@ def mock_app_user_repo(app_user_repo, monkeypatch: MonkeyPatch, mocker):
     def mock_get_app_user_authorisation(
         _, __
     ) -> list[Tuple[OrganisationUser, Organisation]]:
-        return []
+        org_id = (
+            ALTERNATIVE_ORG_ID if app_user_repo.alternative_org else STANDARD_ORG_ID
+        )
+        org = MagicMock()
+        org.id = org_id
+        org.name = f"org-{org_id}"
+        org_user = MagicMock()
+        org_user.is_admin = False
+        return [(org_user, org)]
 
     def mock_get_user_by_email(_, __) -> MaybeAppUser:
         if not app_user_repo.error:
@@ -34,11 +43,6 @@ def mock_app_user_repo(app_user_repo, monkeypatch: MonkeyPatch, mocker):
                 is_superuser=True,
             )
 
-    def mock_get_org_id(_, user_email: str) -> int:
-        if app_user_repo.alternative_org is True:
-            return ALTERNATIVE_ORG_ID
-        return STANDARD_ORG_ID
-
     def mock_is_active(_, email: str) -> bool:
         return bool(app_user_repo.user_active is True)
 
@@ -47,9 +51,6 @@ def mock_app_user_repo(app_user_repo, monkeypatch: MonkeyPatch, mocker):
 
     monkeypatch.setattr(app_user_repo, "get_user_by_email", mock_get_user_by_email)
     mocker.spy(app_user_repo, "get_user_by_email")
-
-    monkeypatch.setattr(app_user_repo, "get_org_id", mock_get_org_id)
-    mocker.spy(app_user_repo, "get_org_id")
 
     monkeypatch.setattr(app_user_repo, "is_active", mock_is_active)
     mocker.spy(app_user_repo, "is_active")

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -274,42 +274,52 @@ def organisation_service_mock(monkeypatch, mocker):
 
 @pytest.fixture
 def superuser_header_token() -> Dict[str, str]:
-    a_token = token_service.encode("super@cpr.org", ORG_ID, True, {"is_admin": True})
+    a_token = token_service.encode(
+        "super@cpr.org", True, {"is_admin": True}, org_ids=[ORG_ID]
+    )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
 
 
 @pytest.fixture
 def non_admin_superuser_header_token() -> Dict[str, str]:
-    a_token = token_service.encode("non-admin-super@cpr.org", ORG_ID, True, {})
+    a_token = token_service.encode(
+        "non-admin-super@cpr.org", True, {}, org_ids=[ORG_ID]
+    )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
 
 
 @pytest.fixture
 def user_header_token() -> Dict[str, str]:
-    a_token = token_service.encode("cclw@cpr.org", ORG_ID, False, {"is_admin": False})
+    a_token = token_service.encode(
+        "cclw@cpr.org", False, {"is_admin": False}, org_ids=[ORG_ID]
+    )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
 
 
 @pytest.fixture
 def admin_user_header_token() -> Dict[str, str]:
-    a_token = token_service.encode("admin@cpr.org", ORG_ID, False, {"is_admin": True})
+    a_token = token_service.encode(
+        "admin@cpr.org", False, {"is_admin": True}, org_ids=[ORG_ID]
+    )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
 
 
 @pytest.fixture
 def non_cclw_user_header_token() -> Dict[str, str]:
-    a_token = token_service.encode("unfccc@cpr.org", ORG_ID, False, {"is_admin": False})
+    a_token = token_service.encode(
+        "unfccc@cpr.org", False, {"is_admin": False}, org_ids=[ORG_ID]
+    )
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
 
 
 @pytest.fixture
 def invalid_user_header_token() -> Dict[str, str]:
-    a_token = token_service.encode("non-admin@cpr.org", ORG_ID, False, {})
+    a_token = token_service.encode("non-admin@cpr.org", False, {}, org_ids=[ORG_ID])
     headers = {"Authorization": f"Bearer {a_token}"}
     return headers
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -388,26 +388,38 @@ def basic_s3_client():
 @pytest.fixture
 def super_user_context():
     return UserContext(
-        email="super@here.com", org_id=50, is_superuser=True, authorisation={}
+        email="super@here.com",
+        org_id=50,
+        org_ids=[50],
+        is_superuser=True,
+        authorisation={},
     )
 
 
 @pytest.fixture
 def admin_user_context():
     return UserContext(
-        email="admin@here.com", org_id=1, is_superuser=False, authorisation={}
+        email="admin@here.com",
+        org_id=1,
+        org_ids=[1],
+        is_superuser=False,
+        authorisation={},
     )
 
 
 @pytest.fixture
 def another_admin_user_context():
     return UserContext(
-        email="another-admin@here.com", org_id=3, is_superuser=False, authorisation={}
+        email="another-admin@here.com",
+        org_id=3,
+        org_ids=[3],
+        is_superuser=False,
+        authorisation={},
     )
 
 
 @pytest.fixture
 def bad_user_context():
     return UserContext(
-        email="not-an-email", org_id=0, is_superuser=False, authorisation={}
+        email="not-an-email", org_id=0, org_ids=[], is_superuser=False, authorisation={}
     )

--- a/tests/unit_tests/service/login/test_authorisation_service.py
+++ b/tests/unit_tests/service/login/test_authorisation_service.py
@@ -65,7 +65,7 @@ def test_can_auth(
     assert user.email == VALID_USERNAME
     assert user.is_superuser is True
     assert user.authorisation is not None
-    assert len(user.authorisation.keys()) == 0
+    assert len(user.authorisation.keys()) == 1
 
     assert app_user_repo_mock.get_user_by_email.call_count == 1
     assert app_user_repo_mock.get_app_user_authorisation.call_count == 1

--- a/tests/unit_tests/service/login/test_token_service.py
+++ b/tests/unit_tests/service/login/test_token_service.py
@@ -26,7 +26,7 @@ from app.errors import TokenError
 def test_ok_when_encoded_and_decoded(
     email: str, org_id: int, is_superuser: bool, authorisation: dict
 ):
-    token = token_service.encode(email, org_id, is_superuser, authorisation)
+    token = token_service.encode(email, is_superuser, authorisation, org_ids=[org_id])
     assert token is not None
     assert len(token) > 200
     user = token_service.decode(token)
@@ -34,11 +34,12 @@ def test_ok_when_encoded_and_decoded(
     assert user.is_superuser == is_superuser
     assert user.authorisation == authorisation
     assert user.org_id == org_id
+    assert user.org_ids == [org_id]
 
 
 def test_encode_checks_authorisation():
     with pytest.raises(TokenError) as e:
-        token_service.encode("email@here.com", 1, False, cast(dict, "random stuff"))
+        token_service.encode("email@here.com", False, cast(dict, "random stuff"))
 
     assert (
         e.value.message == "Parameter authorisation should be a dict, not random stuff"
@@ -47,14 +48,14 @@ def test_encode_checks_authorisation():
 
 def test_encode_checks_email():
     with pytest.raises(TokenError) as e:
-        token_service.encode("email.here.com", 1, False, {})
+        token_service.encode("email.here.com", False, {})
 
     assert e.value.message == "Parameter email should be an email, not email.here.com"
 
 
 def test_encode_checks_is_superuser():
     with pytest.raises(TokenError) as e:
-        token_service.encode("email@here.com", 1, cast(bool, "False"), {})
+        token_service.encode("email@here.com", cast(bool, "False"), {})
 
     assert e.value.message == "Parameter is_superuser should be a bool, not False"
 
@@ -86,4 +87,4 @@ def test_decode_fails_when_no_org_id():
     with pytest.raises(TokenError) as e:
         token_service.decode(encoded_jwt)
 
-    assert e.value.message == "Token did not contain an organisation_id"
+    assert e.value.message == "Token did not contain any organisation_id"


### PR DESCRIPTION
# Description

Expand -> **Migrate** -> Contract

We are here: Migrate

Migrate old single org to multi org capability as part of streamlining data-in for CPR users.

We know the CMS is being retired soon - but this aims to remove the final manual processes from my head so Dominyka can manage this herself.

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] GitHub workflow update
- [ ] Documentation update
- [ ] Remove legacy code
- [ ] Dependency update

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Reviewer Checklist

- [ ] **DB_CLIENT DEPENDENCY IS ON THE LATEST VERSION**
- [ ] The PR represents a single feature (small drive-by fixes are also ok)
- [ ] The PR includes tests that are sufficient for the level of risk
- [ ] The code is sufficiently commented, particularly in hard-to-understand areas
- [ ] Any required documentation updates have been made
- [ ] Any TODOs added are captured in future tickets
- [ ] No FIXMEs remain
